### PR TITLE
add canBeDeleted flag to ruleset schema

### DIFF
--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -280,6 +280,7 @@ components:
         - name
         - status
         - createdAt
+        - canBeDeleted
       properties:
         id:
           type: string
@@ -312,6 +313,10 @@ components:
           description: Date of ruleset creation.
           type: string
           format: date-time
+        canBeDeleted:
+          description: Indicates whether the ruleset can be deleted. If true, the ruleset can be deleted. If false, the ruleset is linked to validated package versions and cannot be deleted.
+          type: boolean
+          example: true
     RulesetCreate:
       type: object
       required:

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -244,7 +244,7 @@ paths:
             application/yaml:
               schema:
                 type: string
-                description: YAML content of spetral ruleset file.
+                description: YAML content of Spectral ruleset file.
           headers:
             Content-Disposition:
               schema:

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -19,7 +19,13 @@ paths:
         - Ruleset Management
       summary: Get a list of rulesets.
       description: >
-        Returns a sorted list of rulesets.
+        Returns a sorted list of rulesets.  
+          The sorting follows a strict order:
+            1. The currently active ruleset (always appears first).
+            2. Rulesets that have never been activated (in order of creation).
+            3. All other rulesets, sorted by the latest activation date (most recent first).
+
+        There is always one active ruleset in the system.
         This operation is available only to users with the `system administrator` role.
       operationId: getRulesets
       parameters:
@@ -47,14 +53,6 @@ paths:
           content:
             application/json:
               schema:
-                description: >
-                  Returns a sorted list of rulesets.  
-                  The sorting follows a strict order:
-                  1. The currently active ruleset (always appears first).
-                  2. Rulesets that have never been activated (in order of creation).
-                  3. All other rulesets, sorted by the latest activation date (most recent first).
-
-                  There is always one active ruleset in the system.
                 type: array
                 minItems: 1
                 items:
@@ -124,6 +122,46 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   /api/v1/rulesets/{id}:
+    get:
+      tags:
+        - Ruleset Management
+      summary: Get ruleset metadata (for validation result popup)
+      description: >
+        Returns the ruleset name, status, and activation history.
+      security: []
+      operationId: getRulesetId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Unique ruleset ID
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ruleset"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
     delete:
       tags:
         - Ruleset Management

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -296,7 +296,10 @@ components:
             - active
             - inactive
         activationHistory:
-          description: Information about periods when rulest was activated/deactivated. If empty, means that ruleset was never activated.
+          description: |
+            Information about periods when rulest was activated/deactivated. 
+            If empty, means that ruleset was never activated.
+            Important: Only the latest 100 activation records are returned.
           type: array
           items:
             type: object

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -128,9 +128,7 @@ paths:
       summary: Get ruleset metadata
       description: >
         Returns the ruleset name, status, and activation history.
-      security:
-        - BearerAuth: []
-        - api-key: []
+        This operation is available to users with the `viewer` role.
       operationId: getRulesetById
       parameters:
         - name: id

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -7,6 +7,7 @@ servers:
   - url: /
 security:
   - BearerAuth: []
+  - api-key: []
   - PersonalAccessToken: []
 tags:
   - name: Ruleset Management
@@ -18,7 +19,8 @@ paths:
         - Ruleset Management
       summary: Get a list of rulesets.
       description: >
-        Returns a sorted list of rulesets. There is always one active ruleset.
+        Returns a sorted list of rulesets.
+        This operation is available only to users with the `system administrator` role.
       operationId: getRulesets
       parameters:
         - name: page
@@ -45,7 +47,16 @@ paths:
           content:
             application/json:
               schema:
+                description: >
+                  Returns a sorted list of rulesets.  
+                  The sorting follows a strict order:
+                  1. The currently active ruleset (always appears first).
+                  2. Rulesets that have never been activated (in order of creation).
+                  3. All other rulesets, sorted by the latest activation date (most recent first).
+
+                  There is always one active ruleset in the system.
                 type: array
+                minItems: 1
                 items:
                   $ref: "#/components/schemas/Ruleset"
         "401":
@@ -73,9 +84,7 @@ paths:
       description: >
         Allows an admin to create a new ruleset by uploading a YAML file.
         The new ruleset is set to 'Inactive' by default.
-      security:
-        - BearerAuth: []
-        - api-key: []
+        This operation is available only to users with the `system administrator` role.
       operationId: postRuleset
       requestBody:
         required: true
@@ -122,6 +131,7 @@ paths:
       description: >
         Delete a ruleset.\
         Ruleset can be deleted if it is in inactive status and no version validated against this ruleset exist.
+        This operation is available only to users with the `system administrator` role.
       operationId: deleteRuleset
       parameters:
         - name: id
@@ -164,6 +174,7 @@ paths:
       summary: Activate a ruleset
       description: >
         Activate an inactive ruleset. Currently active ruleset is automatically deactivated after new ruleset is activated.
+        This operation is available only to users with the `system administrator` role.
       operationId: postRulesetsActivate
       parameters:
         - name: id
@@ -203,7 +214,7 @@ paths:
     get:
       tags:
         - Ruleset Management
-      summary: Download spectral ruleset file
+      summary: Download Spectral ruleset file
       description: >
         Returns the plain YAML content of the ruleset.
       security: []
@@ -215,12 +226,17 @@ paths:
           required: true
           schema:
             type: string
-        - name: inlineContent
+        - name: disposition
           in: query
-          description: Flag to indicate whether spectral ruleset should be displayed inline in the browser or downloaded as an attachment locally.
+          description: >
+            Controls the content disposition of the response.
+            Use `inline` to display in browser, or `attachment` to trigger download locally.
           schema:
-            type: boolean
-            default: false
+            type: string
+            enum:
+              - inline
+              - attachment
+            default: attachment
       responses:
         "200":
           description: Success
@@ -235,6 +251,12 @@ paths:
                 type: string
                 description: Header is required if inlineContent = false. When present, must have "attachment" and "fileName" parameters.
                 example: attachment; filename="<original file name>.yaml"
+            X-Content-Type-Options:
+              schema:
+                type: string
+                enum: [nosniff]
+                example: nosniff
+                description: Prevents MIME-type sniffing.
         "404":
           description: Not found
           content:
@@ -335,14 +357,20 @@ components:
           type: string
           example: "New Ruleset"
         rulesetFile:
-          description: YAML file with spectral rules.
+          description: YAML file with Spectral rules.
           type: string
           format: binary
   securitySchemes:
     BearerAuth:
       type: http
+      description: Bearer token authentication. Default security scheme for API usage.
       scheme: bearer
       bearerFormat: JWT
+    api-key:
+      type: apiKey
+      description: Api-key authentication.
+      name: api-key
+      in: header
     PersonalAccessToken:
       type: apiKey
       description: Authentication by personal access token.

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -203,7 +203,7 @@ paths:
     get:
       tags:
         - Ruleset Management
-      summary: Download spetral ruleset file
+      summary: Download spectral ruleset file
       description: >
         Returns the plain YAML content of the ruleset.
       security: []
@@ -318,10 +318,10 @@ components:
           format: date-time
         canBeDeleted:
           description: |
-            Indicates whether the ruleset can be deleted.
-            This flag is calculated based on both the ruleset's current status and its usage.
-            If the ruleset is active or has been used to validate any existing package versions in the system,
-            canBeDeleted is set to false. Only inactive rulesets with no validated package versions can be deleted.
+            Indicates whether the ruleset can be deleted:
+              - canBeDeleted = true - if both of the following conditins are met:
+                  - ruleset is in inactive status
+                  - there is no existing version revision that was validated against current ruleset.
           type: boolean
           example: true
     RulesetCreate:

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -317,7 +317,11 @@ components:
           type: string
           format: date-time
         canBeDeleted:
-          description: Indicates whether the ruleset can be deleted. If true, the ruleset can be deleted. If false, the ruleset is linked to validated package versions and cannot be deleted.
+          description: |
+            Indicates whether the ruleset can be deleted.
+            This flag is calculated based on both the ruleset's current status and its usage.
+            If the ruleset is active or has been used to validate any existing package versions in the system,
+            canBeDeleted is set to false. Only inactive rulesets with no validated package versions can be deleted.
           type: boolean
           example: true
     RulesetCreate:

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -125,11 +125,13 @@ paths:
     get:
       tags:
         - Ruleset Management
-      summary: Get ruleset metadata (for validation result popup)
+      summary: Get ruleset metadata
       description: >
         Returns the ruleset name, status, and activation history.
-      security: []
-      operationId: getRulesetId
+      security:
+        - BearerAuth: []
+        - api-key: []
+      operationId: getRulesetById
       parameters:
         - name: id
           in: path

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -236,7 +236,7 @@ paths:
             enum:
               - inline
               - attachment
-            default: attachment
+            default: inline
       responses:
         "200":
           description: Success


### PR DESCRIPTION
added `canBeDeleted` flag to the Ruleset schema in the Linter Service API.  
The flag indicates whether a ruleset can be safely deleted (i.e., it's not linked to any validated package versions).









<!-- start messages -->
### Commit messages:
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/f1dfa128da04d2eb3c2b91c3ea988d406fd60ce3) add canBeDeleted flag to ruleset schema
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/3798b3bc3f1c1e9a6d927eacf31f21b5bde78d8d) fix: update description for activationHistory
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/c7658ab856fc2461c2cdd38404d5db560a6655d1) Updated canBeDeleted description
[iugaidiana](https://github.com/Netcracker/qubership-api-linter-service/commit/936e16c90119bd2ea9034c740962e34e838dc019) Minor fixes in descriptions
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/bd5509c20263cdc8797647d78c0f6f1ffbb97333) fix: correct schema structure and update documentation
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/e0f73dead244dddf242779dcf7089fbb30845422) fix: Changed “spetral” to “Spectral” in the response schema description
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/c73ee51f63673e900295659bc77cde55a56e0867) fix: changed default from "attachement" to "inline"
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/983a9922aea9b7ef3f7d774d50031f9ce8dfefff) feat: added 'Get ruleset metadata' endpoint
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/1ad20790a0c752150ce190ac2ad8ef2b5d15e8e5) fix(openapi): update 'Get ruleset metadata' endpoint security, operationId and summary
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/6b9b052be8c3fd67dd30f66ce979eba29cc8bfd7) fix: clarify 'Get ruleset metadata' description for viewer role access
<!-- end messages -->









