### PR TITLE
Validation result

### DIFF
--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -280,6 +280,7 @@ components:
         - name
         - status
         - createdAt
+        - canBeDeleted
       properties:
         id:
           type: string
@@ -312,6 +313,10 @@ components:
           description: Date of ruleset creation.
           type: string
           format: date-time
+        canBeDeleted:
+          description: Indicates whether the ruleset can be deleted. If true, the ruleset can be deleted. If false, the ruleset is linked to validated package versions and cannot be deleted.
+          type: boolean
+          example: true
     RulesetCreate:
       type: object
       required:

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -296,7 +296,10 @@ components:
             - active
             - inactive
         activationHistory:
-          description: Information about periods when rulest was activated/deactivated. If empty, means that ruleset was never activated.
+          description: |
+            Information about periods when rulest was activated/deactivated. 
+            If empty, means that ruleset was never activated.
+            Important: Only the latest 100 activation records are returned.
           type: array
           items:
             type: object

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -11,6 +11,8 @@ security:
 tags:
   - name: Ruleset Management
     description: API related to management of validation rulesets.
+  - name: Validation Result
+    description: API for retrieving Spectral validation results for package versions.
 paths:
   /api/v1/rulesets:
     get:
@@ -115,6 +117,45 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   /api/v1/rulesets/{id}:
+    get:
+      tags:
+        - Ruleset Management
+      summary: Get ruleset metadata (for validation result popup)
+      description: >
+        Returns the ruleset name, status, and activation history.
+      operationId: getRulesetId
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Unique ruleset ID
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ruleset"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
     delete:
       tags:
         - Ruleset Management
@@ -247,6 +288,148 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/packages/{packageId}/versions/{version}/validation/summary:
+    get:
+      tags:
+        - Validation Result
+      summary: Get validation summary for a package version
+      description: >
+        Returns a summary of the validation status for the specified package version,
+        including the ruleset used, quality score, and issue counts grouped by severity.
+      operationId: getPackageVersionValidationSummary
+      parameters:
+        - name: packageId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationSummaryResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/packages/{packageId}/versions/{version}/validation/documents:
+    get:
+      tags:
+        - Validation Result
+      summary: Get validated documents for a package version
+      description: >
+        Retrieves the list of documents that were validated within the specified package version,
+        providing basic metadata like file ID and file name.
+      operationId: getPackageVersionValidationDocuments
+      parameters:
+        - name: packageId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ValidatedDocument"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/packages/{packageId}/versions/{version}/validation/documents/{fileId}/details:
+    get:
+      tags:
+        - Validation Result
+      summary: Get validation result details for a specific document
+      description: >
+        Returns detailed validation results, including the list of violations, severity levels,
+        line numbers for a specific document within the package version.
+      operationId: getPackageVersionValidationDocumentsDetails
+      parameters:
+        - name: packageId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: fileId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationDetailsResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 components:
   schemas:
     ErrorResponse:
@@ -338,6 +521,122 @@ components:
           description: YAML file with spectral rules.
           type: string
           format: binary
+    ValidationSummaryResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          description: Current validation status for the package version.
+          type: string
+          enum:
+            - success
+            - inProgress
+            - noResults
+        ruleset:
+          description: Information about the ruleset used for validation.
+          type: object
+          nullable: true
+          properties:
+            id:
+              description: Unique identifier of the ruleset.
+              type: string
+            name:
+              description: Name of the ruleset.
+              type: string
+            status:
+              description: Current status of the ruleset.
+              type: string
+              enum:
+                - active
+                - inactive
+        issuesSummary:
+          description: Summary of validation issues grouped by severity.
+          type: object
+          properties:
+            error:
+              description: Total number of errors.
+              type: integer
+            warning:
+              description: Total number of warnings.
+              type: integer
+            info:
+              description: Total number of informational messages.
+              type: integer
+    ValidatedDocument:
+      type: object
+      required:
+        - fileId
+        - fileName
+      properties:
+        fileId:
+          description: Unique identifier of the document.
+          type: string
+        fileName:
+          description: Name of the validated document.
+          type: string
+        specificationType:
+          description: Type of the specification notation.
+          type: string
+          enum:
+            - openapi-3-1
+            - openapi-3-0
+            - openapi-2-0
+            - json-schema
+            - markdown
+            - graphql-schema
+            - graphapi
+            - introspection
+            - protobuf-3
+            - unknown
+        title:
+          description: Display title for the document in the UI.
+          type: string
+    ValidationDetailsResponse:
+      type: object
+      required:
+        - validatedBy
+        - violations
+        - document
+      properties:
+        validatedBy:
+          description: Metadata about the ruleset that validated the document.
+          type: object
+          properties:
+            rulesetId:
+              description: Unique identifier of the ruleset.
+              type: string
+            rulesetName:
+              description: Name of the ruleset.
+              type: string
+            status:
+              description: Status of the ruleset during validation.
+              type: string
+              enum:
+                - active
+                - inactive
+        violations:
+          description: List of individual validation violations in the document.
+          type: array
+          items:
+            type: object
+            properties:
+              jsonPath:
+                description: JSON path pointing to the location of the issue in the document.
+                type: string
+              severity:
+                description: Severity level of the issue.
+                type: string
+                enum:
+                  - error
+                  - warning
+                  - info
+              message:
+                description: Description of the validation issue.
+                type: string
+              rule:
+                description: Name or identifier of the violated rule.
+                type: string
   securitySchemes:
     BearerAuth:
       type: http

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -7,6 +7,7 @@ servers:
   - url: /
 security:
   - BearerAuth: []
+  - api-key: []
   - PersonalAccessToken: []
 tags:
   - name: Ruleset Management
@@ -20,7 +21,14 @@ paths:
         - Ruleset Management
       summary: Get a list of rulesets.
       description: >
-        Returns a sorted list of rulesets. There is always one active ruleset.
+        Returns a sorted list of rulesets.  
+          The sorting follows a strict order:
+            1. The currently active ruleset (always appears first).
+            2. Rulesets that have never been activated (in order of creation).
+            3. All other rulesets, sorted by the latest activation date (most recent first).
+
+        There is always one active ruleset in the system.
+        This operation is available only to users with the `system administrator` role.
       operationId: getRulesets
       parameters:
         - name: page
@@ -48,6 +56,7 @@ paths:
             application/json:
               schema:
                 type: array
+                minItems: 1
                 items:
                   $ref: "#/components/schemas/Ruleset"
         "401":
@@ -75,9 +84,7 @@ paths:
       description: >
         Allows an admin to create a new ruleset by uploading a YAML file.
         The new ruleset is set to 'Inactive' by default.
-      security:
-        - BearerAuth: []
-        - api-key: []
+        This operation is available only to users with the `system administrator` role.
       operationId: postRuleset
       requestBody:
         required: true
@@ -120,10 +127,11 @@ paths:
     get:
       tags:
         - Ruleset Management
-      summary: Get ruleset metadata (for validation result popup)
+      summary: Get ruleset metadata
       description: >
         Returns the ruleset name, status, and activation history.
-      operationId: getRulesetId
+        This operation is available to users with the `viewer` role.
+      operationId: getRulesetById
       parameters:
         - name: id
           in: path
@@ -163,6 +171,7 @@ paths:
       description: >
         Delete a ruleset.\
         Ruleset can be deleted if it is in inactive status and no version validated against this ruleset exist.
+        This operation is available only to users with the `system administrator` role.
       operationId: deleteRuleset
       parameters:
         - name: id
@@ -205,6 +214,7 @@ paths:
       summary: Activate a ruleset
       description: >
         Activate an inactive ruleset. Currently active ruleset is automatically deactivated after new ruleset is activated.
+        This operation is available only to users with the `system administrator` role.
       operationId: postRulesetsActivate
       parameters:
         - name: id
@@ -244,7 +254,7 @@ paths:
     get:
       tags:
         - Ruleset Management
-      summary: Download spectral ruleset file
+      summary: Download Spectral ruleset file
       description: >
         Returns the plain YAML content of the ruleset.
       security: []
@@ -256,12 +266,17 @@ paths:
           required: true
           schema:
             type: string
-        - name: inlineContent
+        - name: disposition
           in: query
-          description: Flag to indicate whether spectral ruleset should be displayed inline in the browser or downloaded as an attachment locally.
+          description: >
+            Controls the content disposition of the response.
+            Use `inline` to display in browser, or `attachment` to trigger download locally.
           schema:
-            type: boolean
-            default: false
+            type: string
+            enum:
+              - inline
+              - attachment
+            default: inline
       responses:
         "200":
           description: Success
@@ -269,13 +284,19 @@ paths:
             application/yaml:
               schema:
                 type: string
-                description: YAML content of spetral ruleset file.
+                description: YAML content of Spectral ruleset file.
           headers:
             Content-Disposition:
               schema:
                 type: string
                 description: Header is required if inlineContent = false. When present, must have "attachment" and "fileName" parameters.
                 example: attachment; filename="<original file name>.yaml"
+            X-Content-Type-Options:
+              schema:
+                type: string
+                enum: [nosniff]
+                example: nosniff
+                description: Prevents MIME-type sniffing.
         "404":
           description: Not found
           content:
@@ -314,7 +335,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ValidationSummaryResponse"
+                $ref: "#/components/schemas/ValidationSummary"
         "401":
           description: Unauthorized
           content:
@@ -340,7 +361,7 @@ paths:
       summary: Get validated documents for a package version
       description: >
         Retrieves the list of documents that were validated within the specified package version,
-        providing basic metadata like file ID and file name.
+        providing basic metadata like document ID and document name.
       operationId: getPackageVersionValidationDocuments
       parameters:
         - name: packageId
@@ -380,13 +401,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/packages/{packageId}/versions/{version}/validation/documents/{fileId}/details:
+  /api/v1/packages/{packageId}/versions/{version}/validation/documents/{documentId}/details:
     get:
       tags:
         - Validation Result
       summary: Get validation result details for a specific document
       description: >
-        Returns detailed validation results, including the list of violations, severity levels,
+        Returns detailed validation results, including the list of violations, severity levels,  # написать порядок как оказываем северити
         line numbers for a specific document within the package version.
       operationId: getPackageVersionValidationDocumentsDetails
       parameters:
@@ -400,7 +421,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: fileId
+        - name: documentId
           in: path
           required: true
           schema:
@@ -411,7 +432,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ValidationDetailsResponse"
+                $ref: "#/components/schemas/ValidationDetails"
         "401":
           description: Unauthorized
           content:
@@ -518,10 +539,10 @@ components:
           type: string
           example: "New Ruleset"
         rulesetFile:
-          description: YAML file with spectral rules.
+          description: YAML file with Spectral rules.
           type: string
           format: binary
-    ValidationSummaryResponse:
+    ValidationSummary:
       type: object
       required:
         - status
@@ -566,13 +587,13 @@ components:
     ValidatedDocument:
       type: object
       required:
-        - fileId
-        - fileName
+        - documentId
+        - documentName
       properties:
-        fileId:
+        documentId:
           description: Unique identifier of the document.
           type: string
-        fileName:
+        documentName:
           description: Name of the validated document.
           type: string
         specificationType:
@@ -581,18 +602,11 @@ components:
           enum:
             - openapi-3-1
             - openapi-3-0
-            - openapi-2-0
-            - json-schema
-            - markdown
-            - graphql-schema
-            - graphapi
-            - introspection
-            - protobuf-3
-            - unknown
+            - openapi-2-0 # обсудить с дев командой(также самому попробовать сделать тест линтинга по старому) // у нас в апихабе 2.0 спеки -> конвертируются в 3.0, но по контенту 2.0 будет показывать
         title:
-          description: Display title for the document in the UI.
+          description: Title of the document.
           type: string
-    ValidationDetailsResponse:
+    ValidationDetails:
       type: object
       required:
         - validatedBy
@@ -635,13 +649,19 @@ components:
                 description: Description of the validation issue.
                 type: string
               rule:
-                description: Name or identifier of the violated rule.
+                description: Name of the violated rule.
                 type: string
   securitySchemes:
     BearerAuth:
       type: http
+      description: Bearer token authentication. Default security scheme for API usage.
       scheme: bearer
       bearerFormat: JWT
+    api-key:
+      type: apiKey
+      description: Api-key authentication.
+      name: api-key
+      in: header
     PersonalAccessToken:
       type: apiKey
       description: Authentication by personal access token.

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -203,7 +203,7 @@ paths:
     get:
       tags:
         - Ruleset Management
-      summary: Download spetral ruleset file
+      summary: Download spectral ruleset file
       description: >
         Returns the plain YAML content of the ruleset.
       security: []
@@ -318,10 +318,10 @@ components:
           format: date-time
         canBeDeleted:
           description: |
-            Indicates whether the ruleset can be deleted.
-            This flag is calculated based on both the ruleset's current status and its usage.
-            If the ruleset is active or has been used to validate any existing package versions in the system,
-            canBeDeleted is set to false. Only inactive rulesets with no validated package versions can be deleted.
+            Indicates whether the ruleset can be deleted:
+              - canBeDeleted = true - if both of the following conditins are met:
+                  - ruleset is in inactive status
+                  - there is no existing version revision that was validated against current ruleset.
           type: boolean
           example: true
     RulesetCreate:

--- a/docs/api/linter_service_api.yaml
+++ b/docs/api/linter_service_api.yaml
@@ -317,7 +317,11 @@ components:
           type: string
           format: date-time
         canBeDeleted:
-          description: Indicates whether the ruleset can be deleted. If true, the ruleset can be deleted. If false, the ruleset is linked to validated package versions and cannot be deleted.
+          description: |
+            Indicates whether the ruleset can be deleted.
+            This flag is calculated based on both the ruleset's current status and its usage.
+            If the ruleset is active or has been used to validate any existing package versions in the system,
+            canBeDeleted is set to false. Only inactive rulesets with no validated package versions can be deleted.
           type: boolean
           example: true
     RulesetCreate:


### PR DESCRIPTION
added Validation results operations and related schemas 


<!-- start messages -->
### Commit messages:
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/f1dfa128da04d2eb3c2b91c3ea988d406fd60ce3) add canBeDeleted flag to ruleset schema
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/3798b3bc3f1c1e9a6d927eacf31f21b5bde78d8d) fix: update description for activationHistory
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/c7658ab856fc2461c2cdd38404d5db560a6655d1) Updated canBeDeleted description
[iugaidiana](https://github.com/Netcracker/qubership-api-linter-service/commit/936e16c90119bd2ea9034c740962e34e838dc019) Minor fixes in descriptions
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/7d9a931d1b526f503b549cc264eeb893103dab41) Combined Validation Result with Ruleset Management in one Linter Service spec file
[zloiadil](https://github.com/Netcracker/qubership-api-linter-service/commit/dc16191a733149a1c1e675ccfbd44c626b666f91) fix: updated prepertyName
<!-- end messages -->


