### PR TITLE
feat(apm): consume generic agent skills and rules from central CI store

### DIFF
--- a/.agents/skills/apihub-go-developer/SKILL.md
+++ b/.agents/skills/apihub-go-developer/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: apihub-go-developer
+description: Implements and modifies Go backend services in the APIHub ecosystem (controllers, services, repositories, entities, migrations, wiring, and OpenAPI). Use when adding or changing backend features, REST endpoints, SQL migrations, repository queries, or Go code in APIHub Go repositories.
+---
+
+# APIHub Go Developer
+
+Follow the repository's `AGENTS.md` and deployed project rules. For examples, see [reference.md](reference.md).
+
+## Before coding
+
+1. Confirm requirements are clear; ask the user if not.
+2. For GitHub tickets, use a ticket-planning skill first when planning from an issue.
+3. Read relevant existing code paths before adding new types or endpoints.
+4. Prefer established libraries over custom implementations.
+5. **Bugfixes:** trace root cause (logs, call chain, repro); never ship swallow-and-default patches unless the user explicitly asked for a documented workaround.
+
+## Implementation workflow
+
+1. **API-first** — If REST contract changes, update OpenAPI under the repository's API docs before or alongside code.
+2. **Layers** — controller → service → repository; entity/view DTOs as per existing patterns.
+3. **Conventions** — no magic numbers; `http.StatusXXX` instead of raw status integers; repeated strings as constants; minimal comments; no route-mapping comments.
+4. **Converters** — dependency-free `Make{Name}View` in `entity/` next to the struct.
+5. **Wiring** — new repos/services/controllers at the **end** of their section in the service entry file; `log.Fatalf` for fatal startup wiring errors.
+6. **Migrations** — next unique numeric prefix; paired up/down SQL when rollback is required; run the migration validation script if the repository provides one.
+7. **SQL** — for non-trivial repository SQL, review indices, joins, cardinality, N+1.
+8. **Docs** — update the appropriate doc per the repository documentation index; do not pollute root `README.md` for small features.
+9. **CI linters** — follow deployed CI linter rules (EditorConfig tabs in Go strings, Markdown line length, textlint terms, valid relative links, OpenAPI hygiene).
+10. **GitHub** — use `gh` for issues/PRs; recommend install if missing.
+
+## Migration validation
+
+When the repository ships a migration check script under this skill's directory, run it from the **repository root** after adding or renaming migration files:
+
+**Linux / WSL / Git Bash:**
+
+```bash
+bash .cursor/skills/<skill-name>/scripts/check_migration_numbers.sh
+```
+
+**Windows PowerShell (native):**
+
+```powershell
+powershell -File .cursor/skills/<skill-name>/scripts/check_migration_numbers.ps1
+```
+
+Replace `<skill-name>` with the repository-specific skill that bundles the script (for example `apihub-backend-developer`). Fix any reported duplicate numbers before finishing.
+
+## Completion checklist
+
+Before telling the user the task is done, verify:
+
+- [ ] Requirements met; assumptions stated if any remain.
+- [ ] **Root cause** addressed (bugfixes); no error swallowing or unapproved silent fallbacks.
+- [ ] Go conventions followed.
+- [ ] REST changes reflected in OpenAPI specs when applicable.
+- [ ] Migrations use unique prefix (validation script passed when available).
+- [ ] Documentation updated in the correct file (not root readme for minor items).
+- [ ] CI linter rules applied: line length, links, Go tab indentation in strings.
+- [ ] Complex SQL performance considered.
+- [ ] Proposed **one** concise conventional-commit message (subject + optional body).
+
+Suggest invoking a self-review skill in a **new chat** or with a **different model** for an independent pass over the diff.

--- a/.agents/skills/apihub-go-developer/reference.md
+++ b/.agents/skills/apihub-go-developer/reference.md
@@ -1,0 +1,100 @@
+# APIHub Go Developer — Reference
+
+Read this file when you need examples or general patterns. Keep `SKILL.md` as the workflow checklist.
+
+## CI linters
+
+See deployed CI linter rules (`.cursor/rules/ci-super-linter.mdc` or equivalent). Highlights for agents:
+
+| Area | Rule |
+|------|------|
+| Go prompts in backticks | Tabs for indented lines inside raw strings |
+| Markdown / design docs | Prose ≤400 chars per line; fix links when editing docs |
+| OpenAPI | Match file indentation; no trailing spaces in changed lines |
+| textlint | Use terms from `.github/linters/.textlintrc` when present |
+
+## Error handling — antipatterns
+
+**Reject as a bugfix or new code:**
+
+```go
+if err != nil {
+    log.Error(err)
+    return nil, nil // pretend success with empty data
+}
+
+_ = repo.Save(ctx, ent)
+
+result, _ := fetch() // swallowed error
+
+if err != nil {
+    return defaultConfig() // silent fallback without product requirement
+}
+```
+
+**Prefer:**
+
+```go
+if err != nil {
+    log.Errorf("failed to save entity: %s", err.Error())
+    return nil, err
+}
+```
+
+Controller maps service `error` to client response using project exception helpers and error code constants.
+
+## HTTP status codes
+
+**Good:**
+
+```go
+import "net/http"
+
+w.WriteHeader(http.StatusNotFound)
+```
+
+**Avoid:**
+
+```go
+w.WriteHeader(404)
+```
+
+## Entity → view converter (`Make{Name}View`)
+
+Place dependency-free converters in `entity/` next to the entity struct.
+
+**Good:**
+
+```go
+// entity/ExampleEntity.go
+type ExampleEntity struct {
+    Id   string
+    Name string
+}
+
+func MakeExampleView(ent ExampleEntity) view.Example {
+    return view.Example{
+        Id:   ent.Id,
+        Name: ent.Name,
+    }
+}
+```
+
+**Avoid:**
+
+- Converter in `view/` or `service/` when it only maps fields and has no dependencies.
+- Comments like `// MakeExampleView is GET /examples/{id}`.
+
+If the converter needs repositories or services, keep it in `service/` (or an appropriate layer), not `entity/`.
+
+## Commit message (conventional commits)
+
+Examples:
+
+```text
+feat(search): add FTS config for lite operation search
+
+fix(auth): correct token validation on expired sessions
+```
+
+One line subject; optional body for non-obvious rationale.

--- a/.agents/skills/apihub-go-self-review/SKILL.md
+++ b/.agents/skills/apihub-go-self-review/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: apihub-go-self-review
+description: Reviews Go backend code changes against project standards (AGENTS.md, rules, development guide). Use when the user asks for self-review, code review of a diff, or post-implementation check before commit or PR. Invoke explicitly after another agent or model wrote the code.
+disable-model-invocation: true
+---
+
+# APIHub Go Self-Review
+
+Independent review of Go backend changes. **Do not implement fixes unless the user asks** — report findings first.
+
+## When to use
+
+- After an agent or Copilot generated a feature or fix.
+- Before opening a PR or committing.
+- Prefer a **new chat** or **different model** than the one that wrote the code to reduce confirmation bias.
+
+## Workflow
+
+1. **Scope** — Determine diff scope:
+   - `git diff` (unstaged + staged) or `git diff main...HEAD` / user-provided branch range.
+   - If unclear, ask which files or commits to review.
+2. **Load standards** — Apply `AGENTS.md`, deployed rules (including CI linter rules), and the repository development guide.
+3. **Review** — Walk changed files against the checklist below.
+4. **Report** — Use the output format below with file paths and line references where possible.
+
+## Review checklist
+
+### Requirements and design
+
+- [ ] Changes match stated requirements; no obvious scope creep or missing cases.
+- [ ] Ambiguous behavior was not silently assumed without documenting assumptions.
+- [ ] **Bugfix:** addresses root cause; summary explains why the failure happened and why the fix is correct.
+
+### Error handling (fail fast)
+
+- [ ] No new swallowed errors (`_ = err`, ignored `err`, empty result after failed I/O/DB).
+- [ ] No new silent "default behavior" when an operation failed, unless explicitly required and logged.
+- [ ] Errors propagated or handled at boundary with project error codes and ERROR logging where appropriate.
+- [ ] No symptom-only patch that hides the original failure mode.
+
+### Go conventions
+
+- [ ] No magic numbers without named constants or justified comments.
+- [ ] HTTP responses use `http.StatusXXX`, not raw integers (`200`, `404`, etc.).
+- [ ] Repeated strings extracted to constants.
+- [ ] Comments only where needed; no endpoint/route mapping comments on types.
+- [ ] Dependency-free converters: `Make{Name}View` in `entity/` package.
+- [ ] New repos/services/controllers appended at end of section in the service entry file when applicable.
+- [ ] Fatal wiring failures use `log.Fatalf` where appropriate.
+
+### API and OpenAPI
+
+- [ ] REST changes have matching updates in OpenAPI specs when applicable.
+- [ ] No unapproved breaking public API changes.
+
+### Migrations
+
+- [ ] Unique numeric migration prefix; up/down pairs where expected.
+- [ ] Migration validation script run when the repository provides one.
+
+### SQL performance
+
+- [ ] New/changed repository SQL: indices, joins, filters, cardinality, N+1 risks noted.
+
+### Documentation
+
+- [ ] Right doc updated per repository documentation index; root `README.md` not used for minor features.
+
+### CI linters
+
+- [ ] Markdown prose lines ≤400 characters; valid relative links.
+- [ ] Go raw string prompts use tabs for nested indentation, not spaces.
+- [ ] OpenAPI / YAML edits: no trailing whitespace; `$ref` siblings valid.
+
+### Libraries and tooling
+
+- [ ] No unnecessary reimplementation of standard library / ecosystem solutions.
+- [ ] GitHub operations would use `gh` (not ad-hoc scraping).
+
+## Output format
+
+```markdown
+## Summary
+<1–3 sentences: overall quality and merge readiness>
+
+## Critical
+- `path:line` — issue and suggested fix
+
+## Suggestion
+- `path:line` — improvement
+
+## Nice to have
+- optional polish
+
+## Checklist gaps
+- <any checklist item that could not be verified from the diff>
+```
+
+If there are no findings in a section, write `None`.
+
+## After review
+
+Offer to apply fixes only if the user requests. Optionally suggest a conventional commit message if the change set looks complete.

--- a/.agents/skills/english-developer-style/SKILL.md
+++ b/.agents/skills/english-developer-style/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: english-developer-style
+description: 'British-English-first style guidance for developer-facing text of any length — README and docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, .cpp, .rb, .swift, ...), Javadoc / KDoc / TSDoc / JSDoc, commit messages, PR descriptions and review replies, design docs, changelog entries, UI strings (buttons, labels, placeholders, tooltips), error and log messages, and English-side localisation files (.po, .properties, JSON i18n). Use whenever the task involves English developer text — writing, editing, rewriting, translating, localising, reviewing, proofreading, verifying, auditing, double-checking, sanity-checking, cross-checking, or "checking the wording". Length does not matter: a one-line `msgstr`, a `// FIXME: …` comment, or a three-word button label is in scope. Also covers choice of English identifier names (methods, variables, classes, files, tests) that will be read by humans. Covers em-dash usage, hyphen stacking, sentence structure, that/which, gerunds after "rather than", hedging, inclusive language, and British/American dialect consistency. Do not use for casual chat replies to the user.'
+---
+
+# English developer style
+
+This skill governs natural-language text written for developers and for users of developer tools: README and reference
+pages, code comments and docstrings, commit messages, PR descriptions, changelogs, UI strings, error and log messages,
+and localisation files. Length does not matter — a one-line `msgstr` or a three-word button label goes through the same
+checklist as a multi-page README. It does not govern code itself, marketing copy, or general end-user product copy
+outside developer surfaces.
+
+Defaults: British English, second person, present tense, sentence-case headings, Oxford serial comma. Voice model: a
+knowledgeable colleague who has done this before.
+
+## 1. When to apply
+
+**Engage whenever the task touches English developer-facing text, regardless of length.** The verb in the request — not
+the file size or the "this is just one word" feeling — decides.
+
+Trigger actions:
+
+- **Authoring:** writing new pages, comments, commit messages, PR descriptions, release notes, UI strings, or error and
+  log messages.
+- **Translation and localisation:** translating to or from English; editing `.po`, `.pot`, `.properties`, `.resx`, JSON
+  i18n, Fluent, or ARB files.
+- **Editing:** rewriting an LLM-generated draft before commit (primary use), polishing someone else's prose.
+- **Review and verification:** "check the wording", "does this read well", "is this English natural", "make this sound
+  less AI", "proofread these strings", "verify the translation", "audit the changelog", "double-check the error
+  messages", "cross-check the docstrings against the code".
+
+Covered surfaces:
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments (`//`, `/* … */`, `#`, `--`), docstrings (Javadoc, KDoc, TSDoc,
+  JSDoc, Python docstrings, Rust doc-comments), and the English identifier names you choose for new functions, types,
+  fields, files, and tests. A one-line `// TODO: handle retry` belongs here just as much as a multi-line Javadoc block.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, JSON i18n, `.ftl`,
+  `.arb`. A one-line `msgstr` is in scope.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages.
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Skip *existing* code identifiers, generated API references, third-party quotes, vendor product names, and licence text —
+do not translate or rename them. (When you choose a *new* identifier, the choice itself is in scope; see the bullet on
+source files.) Yield to a more specific style guide if the repository already has one and existing prose is consistent
+with it.
+
+Anti-pattern: "I'm a fluent English speaker, I do not need the skill." Dialect policy, AI-tell catalogue, em-dash and
+hyphen rules, hedging policy, and per-surface templates live here — not in general fluency. If the request touches
+English developer text and the skill is not loaded, stop and load it before answering.
+
+Mechanical checks belong in tooling, not in this skill body:
+
+- spelling and dialect substitutions (Vale plus Hunspell `en_GB` / `en_US`);
+- terminology lists, future-tense, `currently`, `please`/`sorry`, sentence-length warnings (Vale: `Google`, `Microsoft`,
+  GitLab-derived rules);
+- inclusive-language substitutions with per-project allowlists (alex.js or Vale, not in prompts);
+- commit-message grammar (commitlint with Conventional Commits).
+
+Use this skill for the judgement-based work — tone, structure, AI tells, hedging, error-message empathy — that tooling
+cannot enforce reliably.
+
+## 2. Dialect policy
+
+Default to British English: `-ise`, `colour`, `organisation`, `behaviour`; single quotation marks in body prose;
+`DD Month YYYY` dates; `while` not `whilst` unless quoting. Keep the Oxford serial comma in both dialects — it is OUP
+house style as well.
+
+Detect and yield. If a repository's existing prose is more than roughly 5% US-spelled, treat it as `en-US` and match.
+Never mix dialects within a file. If a project pins a dialect in `CONTRIBUTING.md` or a Vale config, that wins.
+
+Do not import the GOV.UK no-contractions rule. Contractions (`don't`, `it's`, `you'll`) are welcome and reduce
+stiffness.
+
+## 3. Voice and tone
+
+Write as a knowledgeable colleague. Address the reader as `you`. Use `we` only for a decision the team has actually
+made, not as a default narrator.
+
+- **Direct, not chatty.** No `Let's`, `Simply`, `It's that easy!`, or exclamation marks outside literal log output.
+- **Specific, not promotional.** Say what the thing does, not how powerful, seamless, or robust it is. Drop adjectives
+  that do not pay rent.
+- **Empathetic, not apologetic.** `Sorry, something went wrong` makes errors look worse. Tell the reader what happened
+  and what to do.
+- **Confident, not hedged.** State the rule; add a caveat only when one is real.
+
+Before / after:
+
+- *Before:* "This powerful guide will simply walk you through everything you need to seamlessly set up the SDK."
+- *After:* "Set up the SDK in four steps. You need a project ID and an API key."
+
+## 4. Sentence and paragraph craft
+
+- **One idea per sentence.** Aim for ≤ 25 words; split anything over 30 unless the structure genuinely needs the length.
+- **Lead with the action or the answer (BLUF).** Put the verb the reader will run, or the conclusion they need, in the
+  first clause.
+- **Limit modifier stacks.** Three or more adjectives stacked before a noun
+  (`a robust scalable cloud-native message broker`) is a rewrite signal.
+- **One idea per paragraph.** First sentence carries the point; the rest supports it.
+- **Active voice by default,** passive when the actor is unknown, uninteresting, or the sentence reads better that way
+  (`The container is restarted on exit`).
+- **Parallel lists.** Every bullet starts with the same part of speech; every step uses the same imperative form.
+
+Before / after:
+
+- *Before:* "With a carefully considered, well-architected configuration strategy, your deployment will run more
+  smoothly."
+- *After:* "A clear configuration layout makes deployments easier to debug."
+
+## 5. Punctuation and AI-tell avoidance
+
+LLM drafts have recognisable habits. Treat the list below as patterns to *reduce*, not tokens to ban — any one signal in
+isolation is weak. Scan for them on every editing pass.
+
+- **Em-dashes.** Use sparingly, and only when a comma, colon, or parenthesis genuinely will not do. Never as a paragraph
+  connector or definition-list separator.
+- **`It's not X, it's Y` / `not only X but also Y`.** Mechanically balanced parallels read like marketing copy. Collapse
+  to the part you actually mean.
+- **Tail `-ing` clauses that add `significance`.** "…enabling teams to deliver value at scale" almost never carries
+  information. Cut.
+- **Formulaic connectors.** Trim `moreover`, `furthermore`, `additionally`, `on the other hand` when an ordinary
+  sentence break does the job.
+- **Vague attributions.** `Widely regarded as`, `has been described as`, `experts agree`. Cite or delete.
+- **Promotional closers.** `…unlocking new possibilities`, `…paving the way for the future of X`. Stop at the technical
+  fact.
+- **Rigid section scaffolding.** `Introduction / Challenges / Future Prospects` lifted onto a technical page. Use the
+  section headings the content needs.
+- **Bullet lists with a bold inline header plus colon on every item.** Fine for genuine term/definition pairs; an AI
+  tell when used to format ordinary prose.
+
+Hyphens, en-dashes, and em-dashes are three different characters. Number ranges take en-dashes (`10–20 requests`);
+compound modifiers take hyphens (`high-throughput pipeline`).
+
+## 6. Hedging and certainty
+
+- **One hedge per sentence at most.** `May possibly sometimes fail` carries no information; pick one.
+- **Present tense for current behaviour.** `The handler retries three times`, not `The handler will retry`.
+- **Reserve `will` for the actual future.** `The build will fail if the secret is missing` is fine because the future is
+  the subject.
+- **Avoid `currently`.** It dates the sentence the moment it is written. Either give a version, or drop it.
+- **No page-topic self-description.** Skip `This guide explains how to…`. Start with the thing.
+
+Before / after:
+
+- *Before:* "This document currently describes how you can potentially configure the optional retry behaviour, which may
+  sometimes be useful."
+- *After:* "Configure retries with `retry.max_attempts`. The default is three."
+
+## 7. Domain modules
+
+### Docs and README
+
+Open with the answer: what the thing is, who it is for, the minimal command to try it. Procedures use numbered steps;
+each step is one discrete action with a verifiable outcome. Link text names the destination (`the apm.yml reference`),
+never `click here`. Inline code in backticks; code blocks language-tagged.
+
+### Javadoc, docstrings, code comments
+
+Document the *why* and the contract: invariants, side effects, ownership, units, thread-safety, error conditions. Skip
+restating the signature — the type system does that already. One short summary sentence first, then details. Avoid
+comments that narrate the next line of code. Comments age: if removing one would not confuse a future reader, do not
+write it.
+
+### Commit messages
+
+Follow Conventional Commits: `type(scope): summary`. Summary is imperative present (`add`, `fix`, `remove`), ≤ 72
+characters, no trailing full stop. Body, after a blank line, explains *why* the change was needed and notes anything
+non-obvious (migration risk, perf trade-off, related incident). Reference issues by ID; do not paraphrase the diff.
+
+- *Before:* `Updated some files to fix the thing that was broken sometimes.`
+- *After:* `fix(auth): refresh token before retry on 401` plus a body explaining the race that caused the original
+  failure.
+
+### PR descriptions
+
+Three short sections, in order: **Why** (the user-visible problem or constraint that forced the change), **What** (one
+paragraph or bulleted change list), **How to verify** (commands, screenshots, or test names). Lead with the motivation:
+a reviewer reads the change list and verification in light of it. Call out breaking changes, migrations, and follow-up
+work explicitly. A reviewer should not have to read the diff to know whether to engage.
+
+### Changelog and release notes
+
+User-facing voice: name the change in terms of what the reader can now do, or what behaviour has changed. Group under
+`Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security` (Keep a Changelog). One sentence per entry; link to the
+PR or commit for detail. Breaking changes get their own block at the top of the version.
+
+- *Before:* `Refactored the resolver pipeline for better performance.`
+- *After:* `Resolver now caches DNS lookups for 30 s, reducing cold-start latency on connection-heavy workloads.`
+
+### Error and log messages
+
+Adapt the Atlassian pattern for developer surfaces: **reason + action + consequence**, in that order, in one or two
+short sentences. No `please`, no `sorry`. Second person if you address the user; third person if you describe state.
+Name the offending input or resource; include identifiers a developer can grep. Logs add structured fields rather than
+padding the message with context.
+
+- *Before:* `Sorry! Something went wrong, please try again later.`
+- *After:* `Cannot open config file '/etc/foo.yaml': permission denied.`
+  `Run as a user with read access, or set FOO_CONFIG to a readable path.`
+
+Warning versus error: warnings describe a situation the program is handling; errors describe one it is not. Match
+severity to prose — do not promote a recoverable retry to an error string.
+
+## 8. Final-pass checklist
+
+Run this once before commit. Each item should take seconds.
+
+- BLUF — does the page, paragraph, or message open with the answer?
+- Length — any sentence over 30 words that does not earn it?
+- Modifiers — any noun carrying three or more adjectives?
+- Em-dashes — count them; if they outnumber commas in a paragraph, rewrite.
+- AI tells — `it's not X, it's Y`, `-ing` significance tails, `moreover`/`furthermore`, vague attributions, promotional
+  closers?
+- Hedging — at most one per sentence; no `currently`; no bare `will`?
+- Self-description — any `This guide explains…` opener?
+- Dialect — spelling and quotation style match the rest of the file?
+- Lists — bullets parallel, steps imperative, headings sentence case?
+- Code — inline identifiers in backticks; code blocks language-tagged; placeholders in `<angle-brackets>`?
+- Domain format — commit follows Conventional Commits; error follows reason + action + consequence; release note is
+  user-visible?
+
+## 9. When to break the rules
+
+Borrowing from Orwell via Google: break any of these rules sooner than write anything outright barbarous. The rules
+exist to make prose clearer; if applying one in a specific spot makes prose worse, do not apply it. In particular:
+
+- Passive voice is correct when the actor is unknown or uninteresting.
+- A long sentence is fine when the idea genuinely is long and splitting it would obscure the logic.
+- An em-dash is the right punctuation when a comma would mis-bind and parentheses would interrupt.
+- A hedge is honest when the underlying behaviour really is conditional.
+- `We` is appropriate for a team decision; `I` is appropriate in a personal release note.
+
+Reach for a deliberate exception consciously, in service of the reader. Drift into a habitual one and the prose stops
+being yours.

--- a/.agents/skills/github-ticket-implementation-planner/SKILL.md
+++ b/.agents/skills/github-ticket-implementation-planner/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: github-ticket-implementation-planner
+description: Plan implementation from a GitHub ticket by clarifying missing requirements, asking explicit questions for ambiguities, analyzing the codebase, and producing a concrete execution plan. After manual approval, publish the approved plan as a comment on the GitHub issue. Use when the user asks to plan work from a GitHub issue, ticket, or task description.
+---
+
+# GitHub Ticket Implementation Planner
+
+## Core Prompt (Verbatim)
+Read ticket description.
+Highlight not clear or missing requirements, ask questions.
+Analyze codebase and build implementation plan.
+
+## Workflow
+1. Read the ticket description and extract goals, scope, constraints, acceptance criteria, and non-functional expectations.
+2. Identify unclear, conflicting, or missing requirements.
+3. Ask clarifying questions before finalizing the plan whenever requirements are ambiguous or incomplete.
+4. Analyze relevant code paths, architecture boundaries, dependencies, and existing patterns in the repository.
+5. Produce an implementation plan with clear, ordered steps and file-level impact.
+6. Wait for manual approval of the plan before publishing it externally.
+7. After manual approval, post the approved plan to the related GitHub issue as a comment.
+
+## Clarification Gate (Strict)
+- Do not finalize an implementation plan if requirements are ambiguous.
+- List open questions explicitly and request answers first.
+- If assumptions are unavoidable, keep them minimal and clearly labeled.
+
+## Output Format
+Use this structure:
+
+```markdown
+## Open Questions
+- Question 1
+
+## Assumptions
+- Assumption 1
+
+## Implementation Plan
+1. Step 1
+2. Step 2
+
+## Risks / Dependencies
+- Risk or dependency 1
+```
+
+If there are no open questions, omit the `Open Questions` section entirely.
+
+## Publishing Rule
+- Never post a draft plan.
+- Post to GitHub issue comments only after the user confirms manual approval.

--- a/.claude/rules/api-first-openapi.md
+++ b/.claude/rules/api-first-openapi.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "docs/api/**"
+  - "**/controller/**"
+---
+
+# API-First OpenAPI
+
+- Backend API development is API-first (see the repository development guide).
+- Any REST endpoint or contract change **must** update the relevant OpenAPI files under the repository's API docs directory.
+- Do not introduce breaking public API changes without versioning and deprecation per the development guide.

--- a/.claude/rules/apihub-go-developer.md
+++ b/.claude/rules/apihub-go-developer.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "**/*.go"
+---
+
+When implementing or modifying Go backend code (controllers, services, repositories,
+migrations, wiring, or OpenAPI) in APIHub Go repositories, apply the
+`apihub-go-developer` skill.

--- a/.claude/rules/apihub-go-self-review.md
+++ b/.claude/rules/apihub-go-self-review.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "**/*.go"
+---
+
+When the user asks for self-review, code review of a diff, or a post-implementation
+check before commit or PR for Go backend changes, apply the `apihub-go-self-review`
+skill.

--- a/.claude/rules/ci-super-linter.md
+++ b/.claude/rules/ci-super-linter.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "**/*.{md,go,yaml,yml}"
+---
+
+# CI linters (super-linter / link checker)
+
+GitHub Actions runs **super-linter** on changed files and **lychee** on `**/*.md`. Follow these rules when you add or edit matching files so PR checks pass without a follow-up lint commit.
+
+Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`, `.markdownlint.json`, `.github/linters/.textlintrc`, `.github/workflows/super-linter.yaml`.
+
+## EditorConfig (Go)
+
+- `*.go`: **tabs** for indentation (`indent_style = tab`, size 4).
+- In raw string literals (e.g. system prompts in `service/*Prompt.go`), nested lines that look indented must use **tabs**, not spaces — editorconfig-checker validates the whole file.
+- Trim trailing whitespace in non-Markdown files; ensure a final newline at EOF.
+
+## Markdown (markdownlint)
+
+- CI validates **changed** Markdown with **MD013 line length 400** on prose (super-linter default for PR diffs).
+- Wrap long paragraphs and list items before 400 characters; use extra bullets or line breaks instead of one very long line.
+- Only one H1 per file (**MD025**); use `##` for main sections in long design docs.
+- Tables are exempt from line-length in `.markdownlint.json`; still keep rows readable.
+
+## Natural language (textlint)
+
+- Follow `.github/linters/.textlintrc` terminology (e.g. `Markdown`, `OpenAPI`, `predefined`, `APIs`, `end-to-end`).
+- Do not add conflicting custom terms (e.g. both `IDS` and `IDs`).
+- Do not add `REST` as a forced term — it causes false positives on the word "rest".
+
+## Markdown links (lychee)
+
+- Links must resolve from the **file's directory** (count `../` carefully).
+- Prefer stable repo-relative links; external URLs must be reachable.
+
+## OpenAPI / YAML
+
+- No trailing whitespace on changed lines in `docs/api/*.yaml`.
+- Match surrounding indentation in large specs; do not reformat unrelated blocks.
+- OpenAPI: avoid bare `$ref` with sibling fields — wrap in `allOf` when adding `description` next to `$ref`.
+
+## SQL migrations (sqlfluff)
+
+- Unique numeric prefix; paired `.up.sql` / `.down.sql` when applicable.
+- Project config in `.sqlfluff` excludes some rules; avoid unnecessary style churn.
+
+## Before finishing
+
+- After editing Markdown, Go prompt strings, or YAML, verify line length (≤400) and link paths.
+- Run migration number script when migrations change (see migration rules).

--- a/.claude/rules/clarify-before-coding.md
+++ b/.claude/rules/clarify-before-coding.md
@@ -1,0 +1,5 @@
+# Clarify Before Coding
+
+- Do not write or modify code until task requirements are clear.
+- Ask the user specific questions when scope, behavior, or acceptance criteria are ambiguous.
+- For **bug reports**, investigate root cause first; do not "fix" by swallowing errors or silent fallbacks (see `AGENTS.md` — Error handling).

--- a/.claude/rules/clarify-before-coding.md
+++ b/.claude/rules/clarify-before-coding.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "**"
+---
+
 # Clarify Before Coding
 
 - Do not write or modify code until task requirements are clear.

--- a/.claude/rules/english-developer-style.md
+++ b/.claude/rules/english-developer-style.md
@@ -1,0 +1,52 @@
+---
+paths:
+  - "**"
+---
+
+## Skill trigger: `english-developer-style`
+
+**You MUST invoke the `english-developer-style` skill BEFORE producing, modifying, translating, or critiquing any
+English developer-facing text.** The skill applies regardless of text length — a one-line error message and a multi-page
+README go through the same checklist.
+
+### Trigger verbs
+
+The skill fires on any of these tasks. The verb in the user request, not the file size, decides.
+
+- write, draft, author, compose
+- edit, rewrite, revise, polish, copy-edit
+- translate, localise (to or from English)
+- review, proofread, verify, audit, double-check, sanity-check, cross-check
+- "check the wording", "does this read well", "is this English natural", "make this sound less AI"
+
+If the user asks about English developer text in any of these modes — even a human-authored draft, even a five-word
+button label — invoke the skill before answering.
+
+### Covered surfaces
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments, docstrings (Javadoc, KDoc, TSDoc, JSDoc, Python docstrings, Rust
+  doc-comments), and the English identifier names you choose for new functions, types, fields, files, and tests.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, `.json` (i18n), `.ftl`,
+  `.arb`.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages (including one-line `msgid` / `msgstr`).
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Short messages count. A single `msgstr "..."` in a `.po` file, a one-line `// FIXME: …` comment in a `.go` file, or a
+three-word button label is in scope.
+
+### When NOT to invoke
+
+- *Existing* code identifiers, product names, CLI flags, file paths, environment variables — do not translate, restyle,
+  or rename them. (When you *choose* a new identifier name, that choice is in scope; see *Covered surfaces*.)
+- Generated API references and verbatim third-party quotes.
+- Files explicitly marked "do not edit" or covered by a repository-specific style guide — yield to the local guide.
+- Casual chat replies to the user.
+
+### Failure mode to avoid
+
+If the request touches English text and the skill has not been invoked, stop and invoke it before continuing.
+Native-speaker intuition is not a substitute: the dialect policy, AI-tell catalogue, em-dash and hyphen rules, hedging
+policy, and per-surface templates live in the skill, not in general fluency.

--- a/.claude/rules/github-ticket-implementation-planner.md
+++ b/.claude/rules/github-ticket-implementation-planner.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "**"
+---
+
+When planning implementation from a GitHub issue, ticket, or task description, apply the
+`github-ticket-implementation-planner` skill.

--- a/.claude/rules/go-comments.md
+++ b/.claude/rules/go-comments.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Go Comments and Converters
+
+## Comments
+
+- Comment only when it materially helps understanding non-obvious logic.
+- Do not comment obvious code.
+- Do not add comments that map structs/functions to HTTP routes (e.g. `// AiChatsListResponse is GET /chats`).
+
+## CI / EditorConfig in Go sources
+
+- Raw string literals (system prompts, embedded templates): continuation lines that look indented must use **tabs**, not spaces — see CI linter rules.
+
+## Entity → view converters
+
+- Converters with **no dependencies** belong in the `entity` package next to the entity struct.
+- Name them `Make{Name}View` (e.g. `MakePackageSearchResultView`).

--- a/.claude/rules/go-constants-and-http.md
+++ b/.claude/rules/go-constants-and-http.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Go Constants and HTTP Status
+
+## Constants and literals
+
+- Do not use magic numbers; declare named constants.
+- If a numeric literal is unavoidable, add a brief comment explaining what it is and why that value is used.
+- If a string literal is repeated, extract it to a constant.
+- Do **not** duplicate config defaults in service code. Defaults belong in centralized config initialization; valid ranges belong on config struct fields via validation tags checked at startup. Services read validated config directly — no `if cfg.X <= 0 { fallback }` for config-backed values.
+
+## HTTP status codes
+
+- Use `net/http` named constants (`http.StatusOK`, `http.StatusBadRequest`, `http.StatusNotFound`, etc.).
+- Do not use raw status integers (e.g. `200`, `400`, `404`) in handlers, middleware, or tests.

--- a/.claude/rules/go-error-handling.md
+++ b/.claude/rules/go-error-handling.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Go Error Handling
+
+- **Bugfixes:** investigate and fix the **root cause**; do not patch symptoms by swallowing errors or forcing default behavior when something failed.
+- **Do not:** `_ = err`; `return nil` / empty data after a failed DB or external call; `log` then continue as if success; catch-all `recover()` without re-panic or proper fatal handling; widen `if err != nil` to ignore and use a zero value unless product spec requires it.
+- **Do:** return `error` from lower layers; handle once at the boundary (controller / job) with proper API error codes and ERROR-level logs.
+- **Fail fast** on misconfiguration and fatal wiring (`log.Fatalf` in service entry files, config validation at startup).
+- Intentional degradation only with explicit product requirement — log the failure and document the fallback.

--- a/.claude/rules/go-migrations.md
+++ b/.claude/rules/go-migrations.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "**/resources/migrations/**"
+---
+
+# Database Migrations
+
+- Use the next unused numeric prefix (check the migrations directory for the current highest).
+- **Never** reuse or duplicate migration numbers.
+- Provide paired `.up.sql` and `.down.sql` files when rollback is required.
+- After adding migrations, run the repository's migration validation script if one is provided (see the repo-specific developer skill).

--- a/.claude/rules/sql-performance.md
+++ b/.claude/rules/sql-performance.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "**/repository/**"
+---
+
+# SQL Performance
+
+When adding or changing non-trivial SQL in repositories:
+
+- Consider required indices for filters, joins, and sort columns.
+- Avoid N+1 query patterns; prefer joins or batch loads where appropriate.
+- Note expected cardinality (rows scanned/returned) for hot paths.
+- Flag full table scans, missing indices, and unbounded result sets.
+- Document performance assumptions in the PR or commit message when risk is non-obvious.

--- a/.claude/skills/apihub-go-developer/SKILL.md
+++ b/.claude/skills/apihub-go-developer/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: apihub-go-developer
+description: Implements and modifies Go backend services in the APIHub ecosystem (controllers, services, repositories, entities, migrations, wiring, and OpenAPI). Use when adding or changing backend features, REST endpoints, SQL migrations, repository queries, or Go code in APIHub Go repositories.
+---
+
+# APIHub Go Developer
+
+Follow the repository's `AGENTS.md` and deployed project rules. For examples, see [reference.md](reference.md).
+
+## Before coding
+
+1. Confirm requirements are clear; ask the user if not.
+2. For GitHub tickets, use a ticket-planning skill first when planning from an issue.
+3. Read relevant existing code paths before adding new types or endpoints.
+4. Prefer established libraries over custom implementations.
+5. **Bugfixes:** trace root cause (logs, call chain, repro); never ship swallow-and-default patches unless the user explicitly asked for a documented workaround.
+
+## Implementation workflow
+
+1. **API-first** — If REST contract changes, update OpenAPI under the repository's API docs before or alongside code.
+2. **Layers** — controller → service → repository; entity/view DTOs as per existing patterns.
+3. **Conventions** — no magic numbers; `http.StatusXXX` instead of raw status integers; repeated strings as constants; minimal comments; no route-mapping comments.
+4. **Converters** — dependency-free `Make{Name}View` in `entity/` next to the struct.
+5. **Wiring** — new repos/services/controllers at the **end** of their section in the service entry file; `log.Fatalf` for fatal startup wiring errors.
+6. **Migrations** — next unique numeric prefix; paired up/down SQL when rollback is required; run the migration validation script if the repository provides one.
+7. **SQL** — for non-trivial repository SQL, review indices, joins, cardinality, N+1.
+8. **Docs** — update the appropriate doc per the repository documentation index; do not pollute root `README.md` for small features.
+9. **CI linters** — follow deployed CI linter rules (EditorConfig tabs in Go strings, Markdown line length, textlint terms, valid relative links, OpenAPI hygiene).
+10. **GitHub** — use `gh` for issues/PRs; recommend install if missing.
+
+## Migration validation
+
+When the repository ships a migration check script under this skill's directory, run it from the **repository root** after adding or renaming migration files:
+
+**Linux / WSL / Git Bash:**
+
+```bash
+bash .cursor/skills/<skill-name>/scripts/check_migration_numbers.sh
+```
+
+**Windows PowerShell (native):**
+
+```powershell
+powershell -File .cursor/skills/<skill-name>/scripts/check_migration_numbers.ps1
+```
+
+Replace `<skill-name>` with the repository-specific skill that bundles the script (for example `apihub-backend-developer`). Fix any reported duplicate numbers before finishing.
+
+## Completion checklist
+
+Before telling the user the task is done, verify:
+
+- [ ] Requirements met; assumptions stated if any remain.
+- [ ] **Root cause** addressed (bugfixes); no error swallowing or unapproved silent fallbacks.
+- [ ] Go conventions followed.
+- [ ] REST changes reflected in OpenAPI specs when applicable.
+- [ ] Migrations use unique prefix (validation script passed when available).
+- [ ] Documentation updated in the correct file (not root readme for minor items).
+- [ ] CI linter rules applied: line length, links, Go tab indentation in strings.
+- [ ] Complex SQL performance considered.
+- [ ] Proposed **one** concise conventional-commit message (subject + optional body).
+
+Suggest invoking a self-review skill in a **new chat** or with a **different model** for an independent pass over the diff.

--- a/.claude/skills/apihub-go-developer/apm.yml
+++ b/.claude/skills/apihub-go-developer/apm.yml
@@ -1,0 +1,3 @@
+name: apihub-go-developer
+version: 0.1.0
+description: Generic Go backend development workflow for APIHub services

--- a/.claude/skills/apihub-go-developer/apm.yml
+++ b/.claude/skills/apihub-go-developer/apm.yml
@@ -1,3 +1,0 @@
-name: apihub-go-developer
-version: 0.1.0
-description: Generic Go backend development workflow for APIHub services

--- a/.claude/skills/apihub-go-developer/reference.md
+++ b/.claude/skills/apihub-go-developer/reference.md
@@ -1,0 +1,100 @@
+# APIHub Go Developer — Reference
+
+Read this file when you need examples or general patterns. Keep `SKILL.md` as the workflow checklist.
+
+## CI linters
+
+See deployed CI linter rules (`.cursor/rules/ci-super-linter.mdc` or equivalent). Highlights for agents:
+
+| Area | Rule |
+|------|------|
+| Go prompts in backticks | Tabs for indented lines inside raw strings |
+| Markdown / design docs | Prose ≤400 chars per line; fix links when editing docs |
+| OpenAPI | Match file indentation; no trailing spaces in changed lines |
+| textlint | Use terms from `.github/linters/.textlintrc` when present |
+
+## Error handling — antipatterns
+
+**Reject as a bugfix or new code:**
+
+```go
+if err != nil {
+    log.Error(err)
+    return nil, nil // pretend success with empty data
+}
+
+_ = repo.Save(ctx, ent)
+
+result, _ := fetch() // swallowed error
+
+if err != nil {
+    return defaultConfig() // silent fallback without product requirement
+}
+```
+
+**Prefer:**
+
+```go
+if err != nil {
+    log.Errorf("failed to save entity: %s", err.Error())
+    return nil, err
+}
+```
+
+Controller maps service `error` to client response using project exception helpers and error code constants.
+
+## HTTP status codes
+
+**Good:**
+
+```go
+import "net/http"
+
+w.WriteHeader(http.StatusNotFound)
+```
+
+**Avoid:**
+
+```go
+w.WriteHeader(404)
+```
+
+## Entity → view converter (`Make{Name}View`)
+
+Place dependency-free converters in `entity/` next to the entity struct.
+
+**Good:**
+
+```go
+// entity/ExampleEntity.go
+type ExampleEntity struct {
+    Id   string
+    Name string
+}
+
+func MakeExampleView(ent ExampleEntity) view.Example {
+    return view.Example{
+        Id:   ent.Id,
+        Name: ent.Name,
+    }
+}
+```
+
+**Avoid:**
+
+- Converter in `view/` or `service/` when it only maps fields and has no dependencies.
+- Comments like `// MakeExampleView is GET /examples/{id}`.
+
+If the converter needs repositories or services, keep it in `service/` (or an appropriate layer), not `entity/`.
+
+## Commit message (conventional commits)
+
+Examples:
+
+```text
+feat(search): add FTS config for lite operation search
+
+fix(auth): correct token validation on expired sessions
+```
+
+One line subject; optional body for non-obvious rationale.

--- a/.claude/skills/apihub-go-self-review/SKILL.md
+++ b/.claude/skills/apihub-go-self-review/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: apihub-go-self-review
+description: Reviews Go backend code changes against project standards (AGENTS.md, rules, development guide). Use when the user asks for self-review, code review of a diff, or post-implementation check before commit or PR. Invoke explicitly after another agent or model wrote the code.
+disable-model-invocation: true
+---
+
+# APIHub Go Self-Review
+
+Independent review of Go backend changes. **Do not implement fixes unless the user asks** — report findings first.
+
+## When to use
+
+- After an agent or Copilot generated a feature or fix.
+- Before opening a PR or committing.
+- Prefer a **new chat** or **different model** than the one that wrote the code to reduce confirmation bias.
+
+## Workflow
+
+1. **Scope** — Determine diff scope:
+   - `git diff` (unstaged + staged) or `git diff main...HEAD` / user-provided branch range.
+   - If unclear, ask which files or commits to review.
+2. **Load standards** — Apply `AGENTS.md`, deployed rules (including CI linter rules), and the repository development guide.
+3. **Review** — Walk changed files against the checklist below.
+4. **Report** — Use the output format below with file paths and line references where possible.
+
+## Review checklist
+
+### Requirements and design
+
+- [ ] Changes match stated requirements; no obvious scope creep or missing cases.
+- [ ] Ambiguous behavior was not silently assumed without documenting assumptions.
+- [ ] **Bugfix:** addresses root cause; summary explains why the failure happened and why the fix is correct.
+
+### Error handling (fail fast)
+
+- [ ] No new swallowed errors (`_ = err`, ignored `err`, empty result after failed I/O/DB).
+- [ ] No new silent "default behavior" when an operation failed, unless explicitly required and logged.
+- [ ] Errors propagated or handled at boundary with project error codes and ERROR logging where appropriate.
+- [ ] No symptom-only patch that hides the original failure mode.
+
+### Go conventions
+
+- [ ] No magic numbers without named constants or justified comments.
+- [ ] HTTP responses use `http.StatusXXX`, not raw integers (`200`, `404`, etc.).
+- [ ] Repeated strings extracted to constants.
+- [ ] Comments only where needed; no endpoint/route mapping comments on types.
+- [ ] Dependency-free converters: `Make{Name}View` in `entity/` package.
+- [ ] New repos/services/controllers appended at end of section in the service entry file when applicable.
+- [ ] Fatal wiring failures use `log.Fatalf` where appropriate.
+
+### API and OpenAPI
+
+- [ ] REST changes have matching updates in OpenAPI specs when applicable.
+- [ ] No unapproved breaking public API changes.
+
+### Migrations
+
+- [ ] Unique numeric migration prefix; up/down pairs where expected.
+- [ ] Migration validation script run when the repository provides one.
+
+### SQL performance
+
+- [ ] New/changed repository SQL: indices, joins, filters, cardinality, N+1 risks noted.
+
+### Documentation
+
+- [ ] Right doc updated per repository documentation index; root `README.md` not used for minor features.
+
+### CI linters
+
+- [ ] Markdown prose lines ≤400 characters; valid relative links.
+- [ ] Go raw string prompts use tabs for nested indentation, not spaces.
+- [ ] OpenAPI / YAML edits: no trailing whitespace; `$ref` siblings valid.
+
+### Libraries and tooling
+
+- [ ] No unnecessary reimplementation of standard library / ecosystem solutions.
+- [ ] GitHub operations would use `gh` (not ad-hoc scraping).
+
+## Output format
+
+```markdown
+## Summary
+<1–3 sentences: overall quality and merge readiness>
+
+## Critical
+- `path:line` — issue and suggested fix
+
+## Suggestion
+- `path:line` — improvement
+
+## Nice to have
+- optional polish
+
+## Checklist gaps
+- <any checklist item that could not be verified from the diff>
+```
+
+If there are no findings in a section, write `None`.
+
+## After review
+
+Offer to apply fixes only if the user requests. Optionally suggest a conventional commit message if the change set looks complete.

--- a/.claude/skills/apihub-go-self-review/apm.yml
+++ b/.claude/skills/apihub-go-self-review/apm.yml
@@ -1,0 +1,3 @@
+name: apihub-go-self-review
+version: 0.1.0
+description: Generic Go backend self-review checklist for APIHub services

--- a/.claude/skills/apihub-go-self-review/apm.yml
+++ b/.claude/skills/apihub-go-self-review/apm.yml
@@ -1,3 +1,0 @@
-name: apihub-go-self-review
-version: 0.1.0
-description: Generic Go backend self-review checklist for APIHub services

--- a/.claude/skills/english-developer-style/SKILL.md
+++ b/.claude/skills/english-developer-style/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: english-developer-style
+description: 'British-English-first style guidance for developer-facing text of any length — README and docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, .cpp, .rb, .swift, ...), Javadoc / KDoc / TSDoc / JSDoc, commit messages, PR descriptions and review replies, design docs, changelog entries, UI strings (buttons, labels, placeholders, tooltips), error and log messages, and English-side localisation files (.po, .properties, JSON i18n). Use whenever the task involves English developer text — writing, editing, rewriting, translating, localising, reviewing, proofreading, verifying, auditing, double-checking, sanity-checking, cross-checking, or "checking the wording". Length does not matter: a one-line `msgstr`, a `// FIXME: …` comment, or a three-word button label is in scope. Also covers choice of English identifier names (methods, variables, classes, files, tests) that will be read by humans. Covers em-dash usage, hyphen stacking, sentence structure, that/which, gerunds after "rather than", hedging, inclusive language, and British/American dialect consistency. Do not use for casual chat replies to the user.'
+---
+
+# English developer style
+
+This skill governs natural-language text written for developers and for users of developer tools: README and reference
+pages, code comments and docstrings, commit messages, PR descriptions, changelogs, UI strings, error and log messages,
+and localisation files. Length does not matter — a one-line `msgstr` or a three-word button label goes through the same
+checklist as a multi-page README. It does not govern code itself, marketing copy, or general end-user product copy
+outside developer surfaces.
+
+Defaults: British English, second person, present tense, sentence-case headings, Oxford serial comma. Voice model: a
+knowledgeable colleague who has done this before.
+
+## 1. When to apply
+
+**Engage whenever the task touches English developer-facing text, regardless of length.** The verb in the request — not
+the file size or the "this is just one word" feeling — decides.
+
+Trigger actions:
+
+- **Authoring:** writing new pages, comments, commit messages, PR descriptions, release notes, UI strings, or error and
+  log messages.
+- **Translation and localisation:** translating to or from English; editing `.po`, `.pot`, `.properties`, `.resx`, JSON
+  i18n, Fluent, or ARB files.
+- **Editing:** rewriting an LLM-generated draft before commit (primary use), polishing someone else's prose.
+- **Review and verification:** "check the wording", "does this read well", "is this English natural", "make this sound
+  less AI", "proofread these strings", "verify the translation", "audit the changelog", "double-check the error
+  messages", "cross-check the docstrings against the code".
+
+Covered surfaces:
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments (`//`, `/* … */`, `#`, `--`), docstrings (Javadoc, KDoc, TSDoc,
+  JSDoc, Python docstrings, Rust doc-comments), and the English identifier names you choose for new functions, types,
+  fields, files, and tests. A one-line `// TODO: handle retry` belongs here just as much as a multi-line Javadoc block.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, JSON i18n, `.ftl`,
+  `.arb`. A one-line `msgstr` is in scope.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages.
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Skip *existing* code identifiers, generated API references, third-party quotes, vendor product names, and licence text —
+do not translate or rename them. (When you choose a *new* identifier, the choice itself is in scope; see the bullet on
+source files.) Yield to a more specific style guide if the repository already has one and existing prose is consistent
+with it.
+
+Anti-pattern: "I'm a fluent English speaker, I do not need the skill." Dialect policy, AI-tell catalogue, em-dash and
+hyphen rules, hedging policy, and per-surface templates live here — not in general fluency. If the request touches
+English developer text and the skill is not loaded, stop and load it before answering.
+
+Mechanical checks belong in tooling, not in this skill body:
+
+- spelling and dialect substitutions (Vale plus Hunspell `en_GB` / `en_US`);
+- terminology lists, future-tense, `currently`, `please`/`sorry`, sentence-length warnings (Vale: `Google`, `Microsoft`,
+  GitLab-derived rules);
+- inclusive-language substitutions with per-project allowlists (alex.js or Vale, not in prompts);
+- commit-message grammar (commitlint with Conventional Commits).
+
+Use this skill for the judgement-based work — tone, structure, AI tells, hedging, error-message empathy — that tooling
+cannot enforce reliably.
+
+## 2. Dialect policy
+
+Default to British English: `-ise`, `colour`, `organisation`, `behaviour`; single quotation marks in body prose;
+`DD Month YYYY` dates; `while` not `whilst` unless quoting. Keep the Oxford serial comma in both dialects — it is OUP
+house style as well.
+
+Detect and yield. If a repository's existing prose is more than roughly 5% US-spelled, treat it as `en-US` and match.
+Never mix dialects within a file. If a project pins a dialect in `CONTRIBUTING.md` or a Vale config, that wins.
+
+Do not import the GOV.UK no-contractions rule. Contractions (`don't`, `it's`, `you'll`) are welcome and reduce
+stiffness.
+
+## 3. Voice and tone
+
+Write as a knowledgeable colleague. Address the reader as `you`. Use `we` only for a decision the team has actually
+made, not as a default narrator.
+
+- **Direct, not chatty.** No `Let's`, `Simply`, `It's that easy!`, or exclamation marks outside literal log output.
+- **Specific, not promotional.** Say what the thing does, not how powerful, seamless, or robust it is. Drop adjectives
+  that do not pay rent.
+- **Empathetic, not apologetic.** `Sorry, something went wrong` makes errors look worse. Tell the reader what happened
+  and what to do.
+- **Confident, not hedged.** State the rule; add a caveat only when one is real.
+
+Before / after:
+
+- *Before:* "This powerful guide will simply walk you through everything you need to seamlessly set up the SDK."
+- *After:* "Set up the SDK in four steps. You need a project ID and an API key."
+
+## 4. Sentence and paragraph craft
+
+- **One idea per sentence.** Aim for ≤ 25 words; split anything over 30 unless the structure genuinely needs the length.
+- **Lead with the action or the answer (BLUF).** Put the verb the reader will run, or the conclusion they need, in the
+  first clause.
+- **Limit modifier stacks.** Three or more adjectives stacked before a noun
+  (`a robust scalable cloud-native message broker`) is a rewrite signal.
+- **One idea per paragraph.** First sentence carries the point; the rest supports it.
+- **Active voice by default,** passive when the actor is unknown, uninteresting, or the sentence reads better that way
+  (`The container is restarted on exit`).
+- **Parallel lists.** Every bullet starts with the same part of speech; every step uses the same imperative form.
+
+Before / after:
+
+- *Before:* "With a carefully considered, well-architected configuration strategy, your deployment will run more
+  smoothly."
+- *After:* "A clear configuration layout makes deployments easier to debug."
+
+## 5. Punctuation and AI-tell avoidance
+
+LLM drafts have recognisable habits. Treat the list below as patterns to *reduce*, not tokens to ban — any one signal in
+isolation is weak. Scan for them on every editing pass.
+
+- **Em-dashes.** Use sparingly, and only when a comma, colon, or parenthesis genuinely will not do. Never as a paragraph
+  connector or definition-list separator.
+- **`It's not X, it's Y` / `not only X but also Y`.** Mechanically balanced parallels read like marketing copy. Collapse
+  to the part you actually mean.
+- **Tail `-ing` clauses that add `significance`.** "…enabling teams to deliver value at scale" almost never carries
+  information. Cut.
+- **Formulaic connectors.** Trim `moreover`, `furthermore`, `additionally`, `on the other hand` when an ordinary
+  sentence break does the job.
+- **Vague attributions.** `Widely regarded as`, `has been described as`, `experts agree`. Cite or delete.
+- **Promotional closers.** `…unlocking new possibilities`, `…paving the way for the future of X`. Stop at the technical
+  fact.
+- **Rigid section scaffolding.** `Introduction / Challenges / Future Prospects` lifted onto a technical page. Use the
+  section headings the content needs.
+- **Bullet lists with a bold inline header plus colon on every item.** Fine for genuine term/definition pairs; an AI
+  tell when used to format ordinary prose.
+
+Hyphens, en-dashes, and em-dashes are three different characters. Number ranges take en-dashes (`10–20 requests`);
+compound modifiers take hyphens (`high-throughput pipeline`).
+
+## 6. Hedging and certainty
+
+- **One hedge per sentence at most.** `May possibly sometimes fail` carries no information; pick one.
+- **Present tense for current behaviour.** `The handler retries three times`, not `The handler will retry`.
+- **Reserve `will` for the actual future.** `The build will fail if the secret is missing` is fine because the future is
+  the subject.
+- **Avoid `currently`.** It dates the sentence the moment it is written. Either give a version, or drop it.
+- **No page-topic self-description.** Skip `This guide explains how to…`. Start with the thing.
+
+Before / after:
+
+- *Before:* "This document currently describes how you can potentially configure the optional retry behaviour, which may
+  sometimes be useful."
+- *After:* "Configure retries with `retry.max_attempts`. The default is three."
+
+## 7. Domain modules
+
+### Docs and README
+
+Open with the answer: what the thing is, who it is for, the minimal command to try it. Procedures use numbered steps;
+each step is one discrete action with a verifiable outcome. Link text names the destination (`the apm.yml reference`),
+never `click here`. Inline code in backticks; code blocks language-tagged.
+
+### Javadoc, docstrings, code comments
+
+Document the *why* and the contract: invariants, side effects, ownership, units, thread-safety, error conditions. Skip
+restating the signature — the type system does that already. One short summary sentence first, then details. Avoid
+comments that narrate the next line of code. Comments age: if removing one would not confuse a future reader, do not
+write it.
+
+### Commit messages
+
+Follow Conventional Commits: `type(scope): summary`. Summary is imperative present (`add`, `fix`, `remove`), ≤ 72
+characters, no trailing full stop. Body, after a blank line, explains *why* the change was needed and notes anything
+non-obvious (migration risk, perf trade-off, related incident). Reference issues by ID; do not paraphrase the diff.
+
+- *Before:* `Updated some files to fix the thing that was broken sometimes.`
+- *After:* `fix(auth): refresh token before retry on 401` plus a body explaining the race that caused the original
+  failure.
+
+### PR descriptions
+
+Three short sections, in order: **Why** (the user-visible problem or constraint that forced the change), **What** (one
+paragraph or bulleted change list), **How to verify** (commands, screenshots, or test names). Lead with the motivation:
+a reviewer reads the change list and verification in light of it. Call out breaking changes, migrations, and follow-up
+work explicitly. A reviewer should not have to read the diff to know whether to engage.
+
+### Changelog and release notes
+
+User-facing voice: name the change in terms of what the reader can now do, or what behaviour has changed. Group under
+`Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security` (Keep a Changelog). One sentence per entry; link to the
+PR or commit for detail. Breaking changes get their own block at the top of the version.
+
+- *Before:* `Refactored the resolver pipeline for better performance.`
+- *After:* `Resolver now caches DNS lookups for 30 s, reducing cold-start latency on connection-heavy workloads.`
+
+### Error and log messages
+
+Adapt the Atlassian pattern for developer surfaces: **reason + action + consequence**, in that order, in one or two
+short sentences. No `please`, no `sorry`. Second person if you address the user; third person if you describe state.
+Name the offending input or resource; include identifiers a developer can grep. Logs add structured fields rather than
+padding the message with context.
+
+- *Before:* `Sorry! Something went wrong, please try again later.`
+- *After:* `Cannot open config file '/etc/foo.yaml': permission denied.`
+  `Run as a user with read access, or set FOO_CONFIG to a readable path.`
+
+Warning versus error: warnings describe a situation the program is handling; errors describe one it is not. Match
+severity to prose — do not promote a recoverable retry to an error string.
+
+## 8. Final-pass checklist
+
+Run this once before commit. Each item should take seconds.
+
+- BLUF — does the page, paragraph, or message open with the answer?
+- Length — any sentence over 30 words that does not earn it?
+- Modifiers — any noun carrying three or more adjectives?
+- Em-dashes — count them; if they outnumber commas in a paragraph, rewrite.
+- AI tells — `it's not X, it's Y`, `-ing` significance tails, `moreover`/`furthermore`, vague attributions, promotional
+  closers?
+- Hedging — at most one per sentence; no `currently`; no bare `will`?
+- Self-description — any `This guide explains…` opener?
+- Dialect — spelling and quotation style match the rest of the file?
+- Lists — bullets parallel, steps imperative, headings sentence case?
+- Code — inline identifiers in backticks; code blocks language-tagged; placeholders in `<angle-brackets>`?
+- Domain format — commit follows Conventional Commits; error follows reason + action + consequence; release note is
+  user-visible?
+
+## 9. When to break the rules
+
+Borrowing from Orwell via Google: break any of these rules sooner than write anything outright barbarous. The rules
+exist to make prose clearer; if applying one in a specific spot makes prose worse, do not apply it. In particular:
+
+- Passive voice is correct when the actor is unknown or uninteresting.
+- A long sentence is fine when the idea genuinely is long and splitting it would obscure the logic.
+- An em-dash is the right punctuation when a comma would mis-bind and parentheses would interrupt.
+- A hedge is honest when the underlying behaviour really is conditional.
+- `We` is appropriate for a team decision; `I` is appropriate in a personal release note.
+
+Reach for a deliberate exception consciously, in service of the reader. Drift into a habitual one and the prose stops
+being yours.

--- a/.claude/skills/github-ticket-implementation-planner/SKILL.md
+++ b/.claude/skills/github-ticket-implementation-planner/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: github-ticket-implementation-planner
+description: Plan implementation from a GitHub ticket by clarifying missing requirements, asking explicit questions for ambiguities, analyzing the codebase, and producing a concrete execution plan. After manual approval, publish the approved plan as a comment on the GitHub issue. Use when the user asks to plan work from a GitHub issue, ticket, or task description.
+---
+
+# GitHub Ticket Implementation Planner
+
+## Core Prompt (Verbatim)
+Read ticket description.
+Highlight not clear or missing requirements, ask questions.
+Analyze codebase and build implementation plan.
+
+## Workflow
+1. Read the ticket description and extract goals, scope, constraints, acceptance criteria, and non-functional expectations.
+2. Identify unclear, conflicting, or missing requirements.
+3. Ask clarifying questions before finalizing the plan whenever requirements are ambiguous or incomplete.
+4. Analyze relevant code paths, architecture boundaries, dependencies, and existing patterns in the repository.
+5. Produce an implementation plan with clear, ordered steps and file-level impact.
+6. Wait for manual approval of the plan before publishing it externally.
+7. After manual approval, post the approved plan to the related GitHub issue as a comment.
+
+## Clarification Gate (Strict)
+- Do not finalize an implementation plan if requirements are ambiguous.
+- List open questions explicitly and request answers first.
+- If assumptions are unavoidable, keep them minimal and clearly labeled.
+
+## Output Format
+Use this structure:
+
+```markdown
+## Open Questions
+- Question 1
+
+## Assumptions
+- Assumption 1
+
+## Implementation Plan
+1. Step 1
+2. Step 2
+
+## Risks / Dependencies
+- Risk or dependency 1
+```
+
+If there are no open questions, omit the `Open Questions` section entirely.
+
+## Publishing Rule
+- Never post a draft plan.
+- Post to GitHub issue comments only after the user confirms manual approval.

--- a/.claude/skills/github-ticket-implementation-planner/apm.yml
+++ b/.claude/skills/github-ticket-implementation-planner/apm.yml
@@ -1,0 +1,3 @@
+name: github-ticket-implementation-planner
+version: 0.1.0
+description: Plan implementation from a GitHub ticket with clarifying questions and an approved plan comment

--- a/.claude/skills/github-ticket-implementation-planner/apm.yml
+++ b/.claude/skills/github-ticket-implementation-planner/apm.yml
@@ -1,3 +1,0 @@
-name: github-ticket-implementation-planner
-version: 0.1.0
-description: Plan implementation from a GitHub ticket with clarifying questions and an approved plan comment

--- a/.cursor/rules/api-first-openapi.mdc
+++ b/.cursor/rules/api-first-openapi.mdc
@@ -1,0 +1,12 @@
+---
+description: API-first OpenAPI sync principle for REST changes
+globs:
+  - "docs/api/**"
+  - "**/controller/**"
+---
+
+# API-First OpenAPI
+
+- Backend API development is API-first (see the repository development guide).
+- Any REST endpoint or contract change **must** update the relevant OpenAPI files under the repository's API docs directory.
+- Do not introduce breaking public API changes without versioning and deprecation per the development guide.

--- a/.cursor/rules/apihub-go-developer.mdc
+++ b/.cursor/rules/apihub-go-developer.mdc
@@ -1,0 +1,8 @@
+---
+description: Go backend development workflow for APIHub services.
+globs: "**/*.go"
+---
+
+When implementing or modifying Go backend code (controllers, services, repositories,
+migrations, wiring, or OpenAPI) in APIHub Go repositories, apply the
+`apihub-go-developer` skill.

--- a/.cursor/rules/apihub-go-self-review.mdc
+++ b/.cursor/rules/apihub-go-self-review.mdc
@@ -1,0 +1,8 @@
+---
+description: Self-review Go backend changes against APIHub project standards.
+globs: "**/*.go"
+---
+
+When the user asks for self-review, code review of a diff, or a post-implementation
+check before commit or PR for Go backend changes, apply the `apihub-go-self-review`
+skill.

--- a/.cursor/rules/ci-super-linter.mdc
+++ b/.cursor/rules/ci-super-linter.mdc
@@ -1,30 +1,42 @@
 ---
-description: CI super-linter and link-check rules for docs, Go, and YAML
-globs: "**/*.{md,go,yaml,yml}"
+description: CI super-linter and MD link checker rules for changed files in APIHub repositories
+globs: "**"
 ---
 
 # CI linters (super-linter / link checker)
 
-GitHub Actions runs **super-linter** on changed files and **lychee** on `**/*.md`. Follow these rules when you add or edit matching files so PR checks pass without a follow-up lint commit.
+GitHub Actions runs **super-linter** on changed files (many languages and formats) and **lychee** on
+repository Markdown. Follow these rules when you add or edit files so PR checks pass without a
+follow-up lint commit.
 
-Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`, `.markdownlint.json`, `.github/linters/.textlintrc`, `.github/workflows/super-linter.yaml`.
+Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`,
+`.github/linters/.markdownlint.json`, `.github/linters/.textlintrc`, `.github/super-linter.env`,
+`.github/workflows/super-linter.yaml`, `.github/workflows/link-checker.yaml`.
 
-## EditorConfig (Go)
+APM-deployed harness trees (`.cursor/`, `.claude/`, `.agents/`, `agent-packages/`, compiled
+`AGENTS.md`) are excluded from CI linters — edit package sources under `agent-packages/` when
+changing skills or rules.
+
+## EditorConfig
 
 - `*.go`: **tabs** for indentation (`indent_style = tab`, size 4).
-- In raw string literals (e.g. system prompts in `service/*Prompt.go`), nested lines that look indented must use **tabs**, not spaces — editorconfig-checker validates the whole file.
+- In raw string literals (e.g. system prompts in `service/*Prompt.go`), nested lines that look
+  indented must use **tabs**, not spaces — editorconfig-checker validates the whole file.
 - Trim trailing whitespace in non-Markdown files; ensure a final newline at EOF.
 
 ## Markdown (markdownlint)
 
-- CI validates **changed** Markdown with **MD013 line length 400** on prose (super-linter default for PR diffs).
-- Wrap long paragraphs and list items before 400 characters; use extra bullets or line breaks instead of one very long line.
+- CI validates **changed** Markdown with **MD013 line length 400** on prose (super-linter default
+  for PR diffs).
+- Wrap long paragraphs and list items before 400 characters; use extra bullets or line breaks
+  instead of one very long line.
 - Only one H1 per file (**MD025**); use `##` for main sections in long design docs.
 - Tables are exempt from line-length in `.markdownlint.json`; still keep rows readable.
 
 ## Natural language (textlint)
 
-- Follow `.github/linters/.textlintrc` terminology (e.g. `Markdown`, `OpenAPI`, `predefined`, `APIs`, `end-to-end`).
+- Follow `.github/linters/.textlintrc` terminology (e.g. `Markdown`, `OpenAPI`, `predefined`,
+  `APIs`, `end-to-end`).
 - Do not add conflicting custom terms (e.g. both `IDS` and `IDs`).
 - Do not add `REST` as a forced term — it causes false positives on the word "rest".
 
@@ -37,7 +49,8 @@ Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`
 
 - No trailing whitespace on changed lines in `docs/api/*.yaml`.
 - Match surrounding indentation in large specs; do not reformat unrelated blocks.
-- OpenAPI: avoid bare `$ref` with sibling fields — wrap in `allOf` when adding `description` next to `$ref`.
+- OpenAPI: avoid bare `$ref` with sibling fields — wrap in `allOf` when adding `description`
+  next to `$ref`.
 
 ## SQL migrations (sqlfluff)
 
@@ -47,4 +60,4 @@ Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`
 ## Before finishing
 
 - After editing Markdown, Go prompt strings, or YAML, verify line length (≤400) and link paths.
-- Run migration number script when migrations change (see migration rules).
+- When Go SQL migrations change, run the migration number check script (see migration rules).

--- a/.cursor/rules/ci-super-linter.mdc
+++ b/.cursor/rules/ci-super-linter.mdc
@@ -1,0 +1,50 @@
+---
+description: CI super-linter and link-check rules for docs, Go, and YAML
+globs: "**/*.{md,go,yaml,yml}"
+---
+
+# CI linters (super-linter / link checker)
+
+GitHub Actions runs **super-linter** on changed files and **lychee** on `**/*.md`. Follow these rules when you add or edit matching files so PR checks pass without a follow-up lint commit.
+
+Config references: `.editorconfig`, `.github/linters/.editorconfig-checker.json`, `.markdownlint.json`, `.github/linters/.textlintrc`, `.github/workflows/super-linter.yaml`.
+
+## EditorConfig (Go)
+
+- `*.go`: **tabs** for indentation (`indent_style = tab`, size 4).
+- In raw string literals (e.g. system prompts in `service/*Prompt.go`), nested lines that look indented must use **tabs**, not spaces — editorconfig-checker validates the whole file.
+- Trim trailing whitespace in non-Markdown files; ensure a final newline at EOF.
+
+## Markdown (markdownlint)
+
+- CI validates **changed** Markdown with **MD013 line length 400** on prose (super-linter default for PR diffs).
+- Wrap long paragraphs and list items before 400 characters; use extra bullets or line breaks instead of one very long line.
+- Only one H1 per file (**MD025**); use `##` for main sections in long design docs.
+- Tables are exempt from line-length in `.markdownlint.json`; still keep rows readable.
+
+## Natural language (textlint)
+
+- Follow `.github/linters/.textlintrc` terminology (e.g. `Markdown`, `OpenAPI`, `predefined`, `APIs`, `end-to-end`).
+- Do not add conflicting custom terms (e.g. both `IDS` and `IDs`).
+- Do not add `REST` as a forced term — it causes false positives on the word "rest".
+
+## Markdown links (lychee)
+
+- Links must resolve from the **file's directory** (count `../` carefully).
+- Prefer stable repo-relative links; external URLs must be reachable.
+
+## OpenAPI / YAML
+
+- No trailing whitespace on changed lines in `docs/api/*.yaml`.
+- Match surrounding indentation in large specs; do not reformat unrelated blocks.
+- OpenAPI: avoid bare `$ref` with sibling fields — wrap in `allOf` when adding `description` next to `$ref`.
+
+## SQL migrations (sqlfluff)
+
+- Unique numeric prefix; paired `.up.sql` / `.down.sql` when applicable.
+- Project config in `.sqlfluff` excludes some rules; avoid unnecessary style churn.
+
+## Before finishing
+
+- After editing Markdown, Go prompt strings, or YAML, verify line length (≤400) and link paths.
+- Run migration number script when migrations change (see migration rules).

--- a/.cursor/rules/clarify-before-coding.mdc
+++ b/.cursor/rules/clarify-before-coding.mdc
@@ -1,5 +1,6 @@
 ---
 description: Ask clarifying questions before generating code when requirements are unclear
+globs: "**"
 ---
 
 # Clarify Before Coding

--- a/.cursor/rules/clarify-before-coding.mdc
+++ b/.cursor/rules/clarify-before-coding.mdc
@@ -1,0 +1,9 @@
+---
+description: Ask clarifying questions before generating code when requirements are unclear
+---
+
+# Clarify Before Coding
+
+- Do not write or modify code until task requirements are clear.
+- Ask the user specific questions when scope, behavior, or acceptance criteria are ambiguous.
+- For **bug reports**, investigate root cause first; do not "fix" by swallowing errors or silent fallbacks (see `AGENTS.md` — Error handling).

--- a/.cursor/rules/english-developer-style.mdc
+++ b/.cursor/rules/english-developer-style.mdc
@@ -1,0 +1,52 @@
+---
+description: British-English-first style rules for developer-facing text of any length — docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, ...), commits, PR descriptions, changelogs, UI strings, error and log messages, and English-side localisation files (.po, .properties, JSON i18n). Triggered by review/translate/verify/proofread, not only writing.
+globs: "**"
+---
+
+## Skill trigger: `english-developer-style`
+
+**You MUST invoke the `english-developer-style` skill BEFORE producing, modifying, translating, or critiquing any
+English developer-facing text.** The skill applies regardless of text length — a one-line error message and a multi-page
+README go through the same checklist.
+
+### Trigger verbs
+
+The skill fires on any of these tasks. The verb in the user request, not the file size, decides.
+
+- write, draft, author, compose
+- edit, rewrite, revise, polish, copy-edit
+- translate, localise (to or from English)
+- review, proofread, verify, audit, double-check, sanity-check, cross-check
+- "check the wording", "does this read well", "is this English natural", "make this sound less AI"
+
+If the user asks about English developer text in any of these modes — even a human-authored draft, even a five-word
+button label — invoke the skill before answering.
+
+### Covered surfaces
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments, docstrings (Javadoc, KDoc, TSDoc, JSDoc, Python docstrings, Rust
+  doc-comments), and the English identifier names you choose for new functions, types, fields, files, and tests.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, `.json` (i18n), `.ftl`,
+  `.arb`.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages (including one-line `msgid` / `msgstr`).
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Short messages count. A single `msgstr "..."` in a `.po` file, a one-line `// FIXME: …` comment in a `.go` file, or a
+three-word button label is in scope.
+
+### When NOT to invoke
+
+- *Existing* code identifiers, product names, CLI flags, file paths, environment variables — do not translate, restyle,
+  or rename them. (When you *choose* a new identifier name, that choice is in scope; see *Covered surfaces*.)
+- Generated API references and verbatim third-party quotes.
+- Files explicitly marked "do not edit" or covered by a repository-specific style guide — yield to the local guide.
+- Casual chat replies to the user.
+
+### Failure mode to avoid
+
+If the request touches English text and the skill has not been invoked, stop and invoke it before continuing.
+Native-speaker intuition is not a substitute: the dialect policy, AI-tell catalogue, em-dash and hyphen rules, hedging
+policy, and per-surface templates live in the skill, not in general fluency.

--- a/.cursor/rules/github-ticket-implementation-planner.mdc
+++ b/.cursor/rules/github-ticket-implementation-planner.mdc
@@ -1,0 +1,7 @@
+---
+description: Plan implementation from a GitHub issue with clarifying questions and approved plan posting.
+globs: "**"
+---
+
+When planning implementation from a GitHub issue, ticket, or task description, apply the
+`github-ticket-implementation-planner` skill.

--- a/.cursor/rules/go-comments.mdc
+++ b/.cursor/rules/go-comments.mdc
@@ -1,0 +1,21 @@
+---
+description: Go comment policy and entity-to-view converter naming
+globs: "**/*.go"
+---
+
+# Go Comments and Converters
+
+## Comments
+
+- Comment only when it materially helps understanding non-obvious logic.
+- Do not comment obvious code.
+- Do not add comments that map structs/functions to HTTP routes (e.g. `// AiChatsListResponse is GET /chats`).
+
+## CI / EditorConfig in Go sources
+
+- Raw string literals (system prompts, embedded templates): continuation lines that look indented must use **tabs**, not spaces — see CI linter rules.
+
+## Entity → view converters
+
+- Converters with **no dependencies** belong in the `entity` package next to the entity struct.
+- Name them `Make{Name}View` (e.g. `MakePackageSearchResultView`).

--- a/.cursor/rules/go-constants-and-http.mdc
+++ b/.cursor/rules/go-constants-and-http.mdc
@@ -1,0 +1,18 @@
+---
+description: Go constants, literals, and HTTP status code conventions
+globs: "**/*.go"
+---
+
+# Go Constants and HTTP Status
+
+## Constants and literals
+
+- Do not use magic numbers; declare named constants.
+- If a numeric literal is unavoidable, add a brief comment explaining what it is and why that value is used.
+- If a string literal is repeated, extract it to a constant.
+- Do **not** duplicate config defaults in service code. Defaults belong in centralized config initialization; valid ranges belong on config struct fields via validation tags checked at startup. Services read validated config directly — no `if cfg.X <= 0 { fallback }` for config-backed values.
+
+## HTTP status codes
+
+- Use `net/http` named constants (`http.StatusOK`, `http.StatusBadRequest`, `http.StatusNotFound`, etc.).
+- Do not use raw status integers (e.g. `200`, `400`, `404`) in handlers, middleware, or tests.

--- a/.cursor/rules/go-error-handling.mdc
+++ b/.cursor/rules/go-error-handling.mdc
@@ -1,0 +1,12 @@
+---
+description: Go error handling — fail fast and fix root cause
+globs: "**/*.go"
+---
+
+# Go Error Handling
+
+- **Bugfixes:** investigate and fix the **root cause**; do not patch symptoms by swallowing errors or forcing default behavior when something failed.
+- **Do not:** `_ = err`; `return nil` / empty data after a failed DB or external call; `log` then continue as if success; catch-all `recover()` without re-panic or proper fatal handling; widen `if err != nil` to ignore and use a zero value unless product spec requires it.
+- **Do:** return `error` from lower layers; handle once at the boundary (controller / job) with proper API error codes and ERROR-level logs.
+- **Fail fast** on misconfiguration and fatal wiring (`log.Fatalf` in service entry files, config validation at startup).
+- Intentional degradation only with explicit product requirement — log the failure and document the fallback.

--- a/.cursor/rules/go-migrations.mdc
+++ b/.cursor/rules/go-migrations.mdc
@@ -1,0 +1,11 @@
+---
+description: SQL migration numbering and file conventions
+globs: "**/resources/migrations/**"
+---
+
+# Database Migrations
+
+- Use the next unused numeric prefix (check the migrations directory for the current highest).
+- **Never** reuse or duplicate migration numbers.
+- Provide paired `.up.sql` and `.down.sql` files when rollback is required.
+- After adding migrations, run the repository's migration validation script if one is provided (see the repo-specific developer skill).

--- a/.cursor/rules/sql-performance.mdc
+++ b/.cursor/rules/sql-performance.mdc
@@ -1,0 +1,14 @@
+---
+description: SQL performance review for repository changes
+globs: "**/repository/**"
+---
+
+# SQL Performance
+
+When adding or changing non-trivial SQL in repositories:
+
+- Consider required indices for filters, joins, and sort columns.
+- Avoid N+1 query patterns; prefer joins or batch loads where appropriate.
+- Note expected cardinality (rows scanned/returned) for hot paths.
+- Flag full table scans, missing indices, and unbounded result sets.
+- Document performance assumptions in the PR or commit message when risk is non-obvious.

--- a/.cursor/skills/apihub-go-developer/SKILL.md
+++ b/.cursor/skills/apihub-go-developer/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: apihub-go-developer
+description: Implements and modifies Go backend services in the APIHub ecosystem (controllers, services, repositories, entities, migrations, wiring, and OpenAPI). Use when adding or changing backend features, REST endpoints, SQL migrations, repository queries, or Go code in APIHub Go repositories.
+---
+
+# APIHub Go Developer
+
+Follow the repository's `AGENTS.md` and deployed project rules. For examples, see [reference.md](reference.md).
+
+## Before coding
+
+1. Confirm requirements are clear; ask the user if not.
+2. For GitHub tickets, use a ticket-planning skill first when planning from an issue.
+3. Read relevant existing code paths before adding new types or endpoints.
+4. Prefer established libraries over custom implementations.
+5. **Bugfixes:** trace root cause (logs, call chain, repro); never ship swallow-and-default patches unless the user explicitly asked for a documented workaround.
+
+## Implementation workflow
+
+1. **API-first** — If REST contract changes, update OpenAPI under the repository's API docs before or alongside code.
+2. **Layers** — controller → service → repository; entity/view DTOs as per existing patterns.
+3. **Conventions** — no magic numbers; `http.StatusXXX` instead of raw status integers; repeated strings as constants; minimal comments; no route-mapping comments.
+4. **Converters** — dependency-free `Make{Name}View` in `entity/` next to the struct.
+5. **Wiring** — new repos/services/controllers at the **end** of their section in the service entry file; `log.Fatalf` for fatal startup wiring errors.
+6. **Migrations** — next unique numeric prefix; paired up/down SQL when rollback is required; run the migration validation script if the repository provides one.
+7. **SQL** — for non-trivial repository SQL, review indices, joins, cardinality, N+1.
+8. **Docs** — update the appropriate doc per the repository documentation index; do not pollute root `README.md` for small features.
+9. **CI linters** — follow deployed CI linter rules (EditorConfig tabs in Go strings, Markdown line length, textlint terms, valid relative links, OpenAPI hygiene).
+10. **GitHub** — use `gh` for issues/PRs; recommend install if missing.
+
+## Migration validation
+
+When the repository ships a migration check script under this skill's directory, run it from the **repository root** after adding or renaming migration files:
+
+**Linux / WSL / Git Bash:**
+
+```bash
+bash .cursor/skills/<skill-name>/scripts/check_migration_numbers.sh
+```
+
+**Windows PowerShell (native):**
+
+```powershell
+powershell -File .cursor/skills/<skill-name>/scripts/check_migration_numbers.ps1
+```
+
+Replace `<skill-name>` with the repository-specific skill that bundles the script (for example `apihub-backend-developer`). Fix any reported duplicate numbers before finishing.
+
+## Completion checklist
+
+Before telling the user the task is done, verify:
+
+- [ ] Requirements met; assumptions stated if any remain.
+- [ ] **Root cause** addressed (bugfixes); no error swallowing or unapproved silent fallbacks.
+- [ ] Go conventions followed.
+- [ ] REST changes reflected in OpenAPI specs when applicable.
+- [ ] Migrations use unique prefix (validation script passed when available).
+- [ ] Documentation updated in the correct file (not root readme for minor items).
+- [ ] CI linter rules applied: line length, links, Go tab indentation in strings.
+- [ ] Complex SQL performance considered.
+- [ ] Proposed **one** concise conventional-commit message (subject + optional body).
+
+Suggest invoking a self-review skill in a **new chat** or with a **different model** for an independent pass over the diff.

--- a/.cursor/skills/apihub-go-developer/apm.yml
+++ b/.cursor/skills/apihub-go-developer/apm.yml
@@ -1,0 +1,3 @@
+name: apihub-go-developer
+version: 0.1.0
+description: Generic Go backend development workflow for APIHub services

--- a/.cursor/skills/apihub-go-developer/apm.yml
+++ b/.cursor/skills/apihub-go-developer/apm.yml
@@ -1,3 +1,0 @@
-name: apihub-go-developer
-version: 0.1.0
-description: Generic Go backend development workflow for APIHub services

--- a/.cursor/skills/apihub-go-developer/reference.md
+++ b/.cursor/skills/apihub-go-developer/reference.md
@@ -1,0 +1,100 @@
+# APIHub Go Developer — Reference
+
+Read this file when you need examples or general patterns. Keep `SKILL.md` as the workflow checklist.
+
+## CI linters
+
+See deployed CI linter rules (`.cursor/rules/ci-super-linter.mdc` or equivalent). Highlights for agents:
+
+| Area | Rule |
+|------|------|
+| Go prompts in backticks | Tabs for indented lines inside raw strings |
+| Markdown / design docs | Prose ≤400 chars per line; fix links when editing docs |
+| OpenAPI | Match file indentation; no trailing spaces in changed lines |
+| textlint | Use terms from `.github/linters/.textlintrc` when present |
+
+## Error handling — antipatterns
+
+**Reject as a bugfix or new code:**
+
+```go
+if err != nil {
+    log.Error(err)
+    return nil, nil // pretend success with empty data
+}
+
+_ = repo.Save(ctx, ent)
+
+result, _ := fetch() // swallowed error
+
+if err != nil {
+    return defaultConfig() // silent fallback without product requirement
+}
+```
+
+**Prefer:**
+
+```go
+if err != nil {
+    log.Errorf("failed to save entity: %s", err.Error())
+    return nil, err
+}
+```
+
+Controller maps service `error` to client response using project exception helpers and error code constants.
+
+## HTTP status codes
+
+**Good:**
+
+```go
+import "net/http"
+
+w.WriteHeader(http.StatusNotFound)
+```
+
+**Avoid:**
+
+```go
+w.WriteHeader(404)
+```
+
+## Entity → view converter (`Make{Name}View`)
+
+Place dependency-free converters in `entity/` next to the entity struct.
+
+**Good:**
+
+```go
+// entity/ExampleEntity.go
+type ExampleEntity struct {
+    Id   string
+    Name string
+}
+
+func MakeExampleView(ent ExampleEntity) view.Example {
+    return view.Example{
+        Id:   ent.Id,
+        Name: ent.Name,
+    }
+}
+```
+
+**Avoid:**
+
+- Converter in `view/` or `service/` when it only maps fields and has no dependencies.
+- Comments like `// MakeExampleView is GET /examples/{id}`.
+
+If the converter needs repositories or services, keep it in `service/` (or an appropriate layer), not `entity/`.
+
+## Commit message (conventional commits)
+
+Examples:
+
+```text
+feat(search): add FTS config for lite operation search
+
+fix(auth): correct token validation on expired sessions
+```
+
+One line subject; optional body for non-obvious rationale.

--- a/.cursor/skills/apihub-go-self-review/SKILL.md
+++ b/.cursor/skills/apihub-go-self-review/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: apihub-go-self-review
+description: Reviews Go backend code changes against project standards (AGENTS.md, rules, development guide). Use when the user asks for self-review, code review of a diff, or post-implementation check before commit or PR. Invoke explicitly after another agent or model wrote the code.
+disable-model-invocation: true
+---
+
+# APIHub Go Self-Review
+
+Independent review of Go backend changes. **Do not implement fixes unless the user asks** — report findings first.
+
+## When to use
+
+- After an agent or Copilot generated a feature or fix.
+- Before opening a PR or committing.
+- Prefer a **new chat** or **different model** than the one that wrote the code to reduce confirmation bias.
+
+## Workflow
+
+1. **Scope** — Determine diff scope:
+   - `git diff` (unstaged + staged) or `git diff main...HEAD` / user-provided branch range.
+   - If unclear, ask which files or commits to review.
+2. **Load standards** — Apply `AGENTS.md`, deployed rules (including CI linter rules), and the repository development guide.
+3. **Review** — Walk changed files against the checklist below.
+4. **Report** — Use the output format below with file paths and line references where possible.
+
+## Review checklist
+
+### Requirements and design
+
+- [ ] Changes match stated requirements; no obvious scope creep or missing cases.
+- [ ] Ambiguous behavior was not silently assumed without documenting assumptions.
+- [ ] **Bugfix:** addresses root cause; summary explains why the failure happened and why the fix is correct.
+
+### Error handling (fail fast)
+
+- [ ] No new swallowed errors (`_ = err`, ignored `err`, empty result after failed I/O/DB).
+- [ ] No new silent "default behavior" when an operation failed, unless explicitly required and logged.
+- [ ] Errors propagated or handled at boundary with project error codes and ERROR logging where appropriate.
+- [ ] No symptom-only patch that hides the original failure mode.
+
+### Go conventions
+
+- [ ] No magic numbers without named constants or justified comments.
+- [ ] HTTP responses use `http.StatusXXX`, not raw integers (`200`, `404`, etc.).
+- [ ] Repeated strings extracted to constants.
+- [ ] Comments only where needed; no endpoint/route mapping comments on types.
+- [ ] Dependency-free converters: `Make{Name}View` in `entity/` package.
+- [ ] New repos/services/controllers appended at end of section in the service entry file when applicable.
+- [ ] Fatal wiring failures use `log.Fatalf` where appropriate.
+
+### API and OpenAPI
+
+- [ ] REST changes have matching updates in OpenAPI specs when applicable.
+- [ ] No unapproved breaking public API changes.
+
+### Migrations
+
+- [ ] Unique numeric migration prefix; up/down pairs where expected.
+- [ ] Migration validation script run when the repository provides one.
+
+### SQL performance
+
+- [ ] New/changed repository SQL: indices, joins, filters, cardinality, N+1 risks noted.
+
+### Documentation
+
+- [ ] Right doc updated per repository documentation index; root `README.md` not used for minor features.
+
+### CI linters
+
+- [ ] Markdown prose lines ≤400 characters; valid relative links.
+- [ ] Go raw string prompts use tabs for nested indentation, not spaces.
+- [ ] OpenAPI / YAML edits: no trailing whitespace; `$ref` siblings valid.
+
+### Libraries and tooling
+
+- [ ] No unnecessary reimplementation of standard library / ecosystem solutions.
+- [ ] GitHub operations would use `gh` (not ad-hoc scraping).
+
+## Output format
+
+```markdown
+## Summary
+<1–3 sentences: overall quality and merge readiness>
+
+## Critical
+- `path:line` — issue and suggested fix
+
+## Suggestion
+- `path:line` — improvement
+
+## Nice to have
+- optional polish
+
+## Checklist gaps
+- <any checklist item that could not be verified from the diff>
+```
+
+If there are no findings in a section, write `None`.
+
+## After review
+
+Offer to apply fixes only if the user requests. Optionally suggest a conventional commit message if the change set looks complete.

--- a/.cursor/skills/apihub-go-self-review/apm.yml
+++ b/.cursor/skills/apihub-go-self-review/apm.yml
@@ -1,0 +1,3 @@
+name: apihub-go-self-review
+version: 0.1.0
+description: Generic Go backend self-review checklist for APIHub services

--- a/.cursor/skills/apihub-go-self-review/apm.yml
+++ b/.cursor/skills/apihub-go-self-review/apm.yml
@@ -1,3 +1,0 @@
-name: apihub-go-self-review
-version: 0.1.0
-description: Generic Go backend self-review checklist for APIHub services

--- a/.cursor/skills/english-developer-style/SKILL.md
+++ b/.cursor/skills/english-developer-style/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: english-developer-style
+description: 'British-English-first style guidance for developer-facing text of any length — README and docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, .cpp, .rb, .swift, ...), Javadoc / KDoc / TSDoc / JSDoc, commit messages, PR descriptions and review replies, design docs, changelog entries, UI strings (buttons, labels, placeholders, tooltips), error and log messages, and English-side localisation files (.po, .properties, JSON i18n). Use whenever the task involves English developer text — writing, editing, rewriting, translating, localising, reviewing, proofreading, verifying, auditing, double-checking, sanity-checking, cross-checking, or "checking the wording". Length does not matter: a one-line `msgstr`, a `// FIXME: …` comment, or a three-word button label is in scope. Also covers choice of English identifier names (methods, variables, classes, files, tests) that will be read by humans. Covers em-dash usage, hyphen stacking, sentence structure, that/which, gerunds after "rather than", hedging, inclusive language, and British/American dialect consistency. Do not use for casual chat replies to the user.'
+---
+
+# English developer style
+
+This skill governs natural-language text written for developers and for users of developer tools: README and reference
+pages, code comments and docstrings, commit messages, PR descriptions, changelogs, UI strings, error and log messages,
+and localisation files. Length does not matter — a one-line `msgstr` or a three-word button label goes through the same
+checklist as a multi-page README. It does not govern code itself, marketing copy, or general end-user product copy
+outside developer surfaces.
+
+Defaults: British English, second person, present tense, sentence-case headings, Oxford serial comma. Voice model: a
+knowledgeable colleague who has done this before.
+
+## 1. When to apply
+
+**Engage whenever the task touches English developer-facing text, regardless of length.** The verb in the request — not
+the file size or the "this is just one word" feeling — decides.
+
+Trigger actions:
+
+- **Authoring:** writing new pages, comments, commit messages, PR descriptions, release notes, UI strings, or error and
+  log messages.
+- **Translation and localisation:** translating to or from English; editing `.po`, `.pot`, `.properties`, `.resx`, JSON
+  i18n, Fluent, or ARB files.
+- **Editing:** rewriting an LLM-generated draft before commit (primary use), polishing someone else's prose.
+- **Review and verification:** "check the wording", "does this read well", "is this English natural", "make this sound
+  less AI", "proofread these strings", "verify the translation", "audit the changelog", "double-check the error
+  messages", "cross-check the docstrings against the code".
+
+Covered surfaces:
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments (`//`, `/* … */`, `#`, `--`), docstrings (Javadoc, KDoc, TSDoc,
+  JSDoc, Python docstrings, Rust doc-comments), and the English identifier names you choose for new functions, types,
+  fields, files, and tests. A one-line `// TODO: handle retry` belongs here just as much as a multi-line Javadoc block.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, JSON i18n, `.ftl`,
+  `.arb`. A one-line `msgstr` is in scope.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages.
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Skip *existing* code identifiers, generated API references, third-party quotes, vendor product names, and licence text —
+do not translate or rename them. (When you choose a *new* identifier, the choice itself is in scope; see the bullet on
+source files.) Yield to a more specific style guide if the repository already has one and existing prose is consistent
+with it.
+
+Anti-pattern: "I'm a fluent English speaker, I do not need the skill." Dialect policy, AI-tell catalogue, em-dash and
+hyphen rules, hedging policy, and per-surface templates live here — not in general fluency. If the request touches
+English developer text and the skill is not loaded, stop and load it before answering.
+
+Mechanical checks belong in tooling, not in this skill body:
+
+- spelling and dialect substitutions (Vale plus Hunspell `en_GB` / `en_US`);
+- terminology lists, future-tense, `currently`, `please`/`sorry`, sentence-length warnings (Vale: `Google`, `Microsoft`,
+  GitLab-derived rules);
+- inclusive-language substitutions with per-project allowlists (alex.js or Vale, not in prompts);
+- commit-message grammar (commitlint with Conventional Commits).
+
+Use this skill for the judgement-based work — tone, structure, AI tells, hedging, error-message empathy — that tooling
+cannot enforce reliably.
+
+## 2. Dialect policy
+
+Default to British English: `-ise`, `colour`, `organisation`, `behaviour`; single quotation marks in body prose;
+`DD Month YYYY` dates; `while` not `whilst` unless quoting. Keep the Oxford serial comma in both dialects — it is OUP
+house style as well.
+
+Detect and yield. If a repository's existing prose is more than roughly 5% US-spelled, treat it as `en-US` and match.
+Never mix dialects within a file. If a project pins a dialect in `CONTRIBUTING.md` or a Vale config, that wins.
+
+Do not import the GOV.UK no-contractions rule. Contractions (`don't`, `it's`, `you'll`) are welcome and reduce
+stiffness.
+
+## 3. Voice and tone
+
+Write as a knowledgeable colleague. Address the reader as `you`. Use `we` only for a decision the team has actually
+made, not as a default narrator.
+
+- **Direct, not chatty.** No `Let's`, `Simply`, `It's that easy!`, or exclamation marks outside literal log output.
+- **Specific, not promotional.** Say what the thing does, not how powerful, seamless, or robust it is. Drop adjectives
+  that do not pay rent.
+- **Empathetic, not apologetic.** `Sorry, something went wrong` makes errors look worse. Tell the reader what happened
+  and what to do.
+- **Confident, not hedged.** State the rule; add a caveat only when one is real.
+
+Before / after:
+
+- *Before:* "This powerful guide will simply walk you through everything you need to seamlessly set up the SDK."
+- *After:* "Set up the SDK in four steps. You need a project ID and an API key."
+
+## 4. Sentence and paragraph craft
+
+- **One idea per sentence.** Aim for ≤ 25 words; split anything over 30 unless the structure genuinely needs the length.
+- **Lead with the action or the answer (BLUF).** Put the verb the reader will run, or the conclusion they need, in the
+  first clause.
+- **Limit modifier stacks.** Three or more adjectives stacked before a noun
+  (`a robust scalable cloud-native message broker`) is a rewrite signal.
+- **One idea per paragraph.** First sentence carries the point; the rest supports it.
+- **Active voice by default,** passive when the actor is unknown, uninteresting, or the sentence reads better that way
+  (`The container is restarted on exit`).
+- **Parallel lists.** Every bullet starts with the same part of speech; every step uses the same imperative form.
+
+Before / after:
+
+- *Before:* "With a carefully considered, well-architected configuration strategy, your deployment will run more
+  smoothly."
+- *After:* "A clear configuration layout makes deployments easier to debug."
+
+## 5. Punctuation and AI-tell avoidance
+
+LLM drafts have recognisable habits. Treat the list below as patterns to *reduce*, not tokens to ban — any one signal in
+isolation is weak. Scan for them on every editing pass.
+
+- **Em-dashes.** Use sparingly, and only when a comma, colon, or parenthesis genuinely will not do. Never as a paragraph
+  connector or definition-list separator.
+- **`It's not X, it's Y` / `not only X but also Y`.** Mechanically balanced parallels read like marketing copy. Collapse
+  to the part you actually mean.
+- **Tail `-ing` clauses that add `significance`.** "…enabling teams to deliver value at scale" almost never carries
+  information. Cut.
+- **Formulaic connectors.** Trim `moreover`, `furthermore`, `additionally`, `on the other hand` when an ordinary
+  sentence break does the job.
+- **Vague attributions.** `Widely regarded as`, `has been described as`, `experts agree`. Cite or delete.
+- **Promotional closers.** `…unlocking new possibilities`, `…paving the way for the future of X`. Stop at the technical
+  fact.
+- **Rigid section scaffolding.** `Introduction / Challenges / Future Prospects` lifted onto a technical page. Use the
+  section headings the content needs.
+- **Bullet lists with a bold inline header plus colon on every item.** Fine for genuine term/definition pairs; an AI
+  tell when used to format ordinary prose.
+
+Hyphens, en-dashes, and em-dashes are three different characters. Number ranges take en-dashes (`10–20 requests`);
+compound modifiers take hyphens (`high-throughput pipeline`).
+
+## 6. Hedging and certainty
+
+- **One hedge per sentence at most.** `May possibly sometimes fail` carries no information; pick one.
+- **Present tense for current behaviour.** `The handler retries three times`, not `The handler will retry`.
+- **Reserve `will` for the actual future.** `The build will fail if the secret is missing` is fine because the future is
+  the subject.
+- **Avoid `currently`.** It dates the sentence the moment it is written. Either give a version, or drop it.
+- **No page-topic self-description.** Skip `This guide explains how to…`. Start with the thing.
+
+Before / after:
+
+- *Before:* "This document currently describes how you can potentially configure the optional retry behaviour, which may
+  sometimes be useful."
+- *After:* "Configure retries with `retry.max_attempts`. The default is three."
+
+## 7. Domain modules
+
+### Docs and README
+
+Open with the answer: what the thing is, who it is for, the minimal command to try it. Procedures use numbered steps;
+each step is one discrete action with a verifiable outcome. Link text names the destination (`the apm.yml reference`),
+never `click here`. Inline code in backticks; code blocks language-tagged.
+
+### Javadoc, docstrings, code comments
+
+Document the *why* and the contract: invariants, side effects, ownership, units, thread-safety, error conditions. Skip
+restating the signature — the type system does that already. One short summary sentence first, then details. Avoid
+comments that narrate the next line of code. Comments age: if removing one would not confuse a future reader, do not
+write it.
+
+### Commit messages
+
+Follow Conventional Commits: `type(scope): summary`. Summary is imperative present (`add`, `fix`, `remove`), ≤ 72
+characters, no trailing full stop. Body, after a blank line, explains *why* the change was needed and notes anything
+non-obvious (migration risk, perf trade-off, related incident). Reference issues by ID; do not paraphrase the diff.
+
+- *Before:* `Updated some files to fix the thing that was broken sometimes.`
+- *After:* `fix(auth): refresh token before retry on 401` plus a body explaining the race that caused the original
+  failure.
+
+### PR descriptions
+
+Three short sections, in order: **Why** (the user-visible problem or constraint that forced the change), **What** (one
+paragraph or bulleted change list), **How to verify** (commands, screenshots, or test names). Lead with the motivation:
+a reviewer reads the change list and verification in light of it. Call out breaking changes, migrations, and follow-up
+work explicitly. A reviewer should not have to read the diff to know whether to engage.
+
+### Changelog and release notes
+
+User-facing voice: name the change in terms of what the reader can now do, or what behaviour has changed. Group under
+`Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security` (Keep a Changelog). One sentence per entry; link to the
+PR or commit for detail. Breaking changes get their own block at the top of the version.
+
+- *Before:* `Refactored the resolver pipeline for better performance.`
+- *After:* `Resolver now caches DNS lookups for 30 s, reducing cold-start latency on connection-heavy workloads.`
+
+### Error and log messages
+
+Adapt the Atlassian pattern for developer surfaces: **reason + action + consequence**, in that order, in one or two
+short sentences. No `please`, no `sorry`. Second person if you address the user; third person if you describe state.
+Name the offending input or resource; include identifiers a developer can grep. Logs add structured fields rather than
+padding the message with context.
+
+- *Before:* `Sorry! Something went wrong, please try again later.`
+- *After:* `Cannot open config file '/etc/foo.yaml': permission denied.`
+  `Run as a user with read access, or set FOO_CONFIG to a readable path.`
+
+Warning versus error: warnings describe a situation the program is handling; errors describe one it is not. Match
+severity to prose — do not promote a recoverable retry to an error string.
+
+## 8. Final-pass checklist
+
+Run this once before commit. Each item should take seconds.
+
+- BLUF — does the page, paragraph, or message open with the answer?
+- Length — any sentence over 30 words that does not earn it?
+- Modifiers — any noun carrying three or more adjectives?
+- Em-dashes — count them; if they outnumber commas in a paragraph, rewrite.
+- AI tells — `it's not X, it's Y`, `-ing` significance tails, `moreover`/`furthermore`, vague attributions, promotional
+  closers?
+- Hedging — at most one per sentence; no `currently`; no bare `will`?
+- Self-description — any `This guide explains…` opener?
+- Dialect — spelling and quotation style match the rest of the file?
+- Lists — bullets parallel, steps imperative, headings sentence case?
+- Code — inline identifiers in backticks; code blocks language-tagged; placeholders in `<angle-brackets>`?
+- Domain format — commit follows Conventional Commits; error follows reason + action + consequence; release note is
+  user-visible?
+
+## 9. When to break the rules
+
+Borrowing from Orwell via Google: break any of these rules sooner than write anything outright barbarous. The rules
+exist to make prose clearer; if applying one in a specific spot makes prose worse, do not apply it. In particular:
+
+- Passive voice is correct when the actor is unknown or uninteresting.
+- A long sentence is fine when the idea genuinely is long and splitting it would obscure the logic.
+- An em-dash is the right punctuation when a comma would mis-bind and parentheses would interrupt.
+- A hedge is honest when the underlying behaviour really is conditional.
+- `We` is appropriate for a team decision; `I` is appropriate in a personal release note.
+
+Reach for a deliberate exception consciously, in service of the reader. Drift into a habitual one and the prose stops
+being yours.

--- a/.cursor/skills/github-ticket-implementation-planner/SKILL.md
+++ b/.cursor/skills/github-ticket-implementation-planner/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: github-ticket-implementation-planner
+description: Plan implementation from a GitHub ticket by clarifying missing requirements, asking explicit questions for ambiguities, analyzing the codebase, and producing a concrete execution plan. After manual approval, publish the approved plan as a comment on the GitHub issue. Use when the user asks to plan work from a GitHub issue, ticket, or task description.
+---
+
+# GitHub Ticket Implementation Planner
+
+## Core Prompt (Verbatim)
+Read ticket description.
+Highlight not clear or missing requirements, ask questions.
+Analyze codebase and build implementation plan.
+
+## Workflow
+1. Read the ticket description and extract goals, scope, constraints, acceptance criteria, and non-functional expectations.
+2. Identify unclear, conflicting, or missing requirements.
+3. Ask clarifying questions before finalizing the plan whenever requirements are ambiguous or incomplete.
+4. Analyze relevant code paths, architecture boundaries, dependencies, and existing patterns in the repository.
+5. Produce an implementation plan with clear, ordered steps and file-level impact.
+6. Wait for manual approval of the plan before publishing it externally.
+7. After manual approval, post the approved plan to the related GitHub issue as a comment.
+
+## Clarification Gate (Strict)
+- Do not finalize an implementation plan if requirements are ambiguous.
+- List open questions explicitly and request answers first.
+- If assumptions are unavoidable, keep them minimal and clearly labeled.
+
+## Output Format
+Use this structure:
+
+```markdown
+## Open Questions
+- Question 1
+
+## Assumptions
+- Assumption 1
+
+## Implementation Plan
+1. Step 1
+2. Step 2
+
+## Risks / Dependencies
+- Risk or dependency 1
+```
+
+If there are no open questions, omit the `Open Questions` section entirely.
+
+## Publishing Rule
+- Never post a draft plan.
+- Post to GitHub issue comments only after the user confirms manual approval.

--- a/.cursor/skills/github-ticket-implementation-planner/apm.yml
+++ b/.cursor/skills/github-ticket-implementation-planner/apm.yml
@@ -1,0 +1,3 @@
+name: github-ticket-implementation-planner
+version: 0.1.0
+description: Plan implementation from a GitHub ticket with clarifying questions and an approved plan comment

--- a/.cursor/skills/github-ticket-implementation-planner/apm.yml
+++ b/.cursor/skills/github-ticket-implementation-planner/apm.yml
@@ -1,3 +1,0 @@
-name: github-ticket-implementation-planner
-version: 0.1.0
-description: Plan implementation from a GitHub ticket with clarifying questions and an approved plan comment

--- a/.github/instructions/api-first-openapi.instructions.md
+++ b/.github/instructions/api-first-openapi.instructions.md
@@ -1,0 +1,10 @@
+---
+description: API-first OpenAPI sync principle for REST changes
+applyTo: "docs/api/**,**/controller/**"
+---
+
+# API-First OpenAPI
+
+- Backend API development is API-first (see the repository development guide).
+- Any REST endpoint or contract change **must** update the relevant OpenAPI files under the repository's API docs directory.
+- Do not introduce breaking public API changes without versioning and deprecation per the development guide.

--- a/.github/instructions/apihub-go-developer.instructions.md
+++ b/.github/instructions/apihub-go-developer.instructions.md
@@ -1,0 +1,8 @@
+---
+description: Go backend development workflow for APIHub services.
+applyTo: "**/*.go"
+---
+
+When implementing or modifying Go backend code (controllers, services, repositories,
+migrations, wiring, or OpenAPI) in APIHub Go repositories, apply the
+`apihub-go-developer` skill.

--- a/.github/instructions/apihub-go-self-review.instructions.md
+++ b/.github/instructions/apihub-go-self-review.instructions.md
@@ -1,0 +1,8 @@
+---
+description: Self-review Go backend changes against APIHub project standards.
+applyTo: "**/*.go"
+---
+
+When the user asks for self-review, code review of a diff, or a post-implementation
+check before commit or PR for Go backend changes, apply the `apihub-go-self-review`
+skill.

--- a/.github/instructions/ci-super-linter.instructions.md
+++ b/.github/instructions/ci-super-linter.instructions.md
@@ -1,6 +1,6 @@
 ---
-paths:
-  - "**"
+description: CI super-linter and MD link checker rules for changed files in APIHub repositories
+applyTo: "**"
 ---
 
 # CI linters (super-linter / link checker)

--- a/.github/instructions/clarify-before-coding.instructions.md
+++ b/.github/instructions/clarify-before-coding.instructions.md
@@ -1,0 +1,10 @@
+---
+description: Ask clarifying questions before generating code when requirements are unclear
+applyTo: "**"
+---
+
+# Clarify Before Coding
+
+- Do not write or modify code until task requirements are clear.
+- Ask the user specific questions when scope, behavior, or acceptance criteria are ambiguous.
+- For **bug reports**, investigate root cause first; do not "fix" by swallowing errors or silent fallbacks (see `AGENTS.md` — Error handling).

--- a/.github/instructions/english-developer-style.instructions.md
+++ b/.github/instructions/english-developer-style.instructions.md
@@ -1,0 +1,52 @@
+---
+description: British-English-first style rules for developer-facing text of any length — docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, ...), commits, PR descriptions, changelogs, UI strings, error and log messages, and English-side localisation files (.po, .properties, JSON i18n). Triggered by review/translate/verify/proofread, not only writing.
+applyTo: "**"
+---
+
+## Skill trigger: `english-developer-style`
+
+**You MUST invoke the `english-developer-style` skill BEFORE producing, modifying, translating, or critiquing any
+English developer-facing text.** The skill applies regardless of text length — a one-line error message and a multi-page
+README go through the same checklist.
+
+### Trigger verbs
+
+The skill fires on any of these tasks. The verb in the user request, not the file size, decides.
+
+- write, draft, author, compose
+- edit, rewrite, revise, polish, copy-edit
+- translate, localise (to or from English)
+- review, proofread, verify, audit, double-check, sanity-check, cross-check
+- "check the wording", "does this read well", "is this English natural", "make this sound less AI"
+
+If the user asks about English developer text in any of these modes — even a human-authored draft, even a five-word
+button label — invoke the skill before answering.
+
+### Covered surfaces
+
+- Markdown: README, reference docs, design docs, ADR, runbooks, changelog, release notes.
+- Source files (`.go`, `.js`, `.ts`, `.py`, `.java`, `.rs`, `.kt`, `.cs`, `.cpp`, `.rb`, `.swift`, `.scala`, `.php`,
+  ...): all English text inside them — code comments, docstrings (Javadoc, KDoc, TSDoc, JSDoc, Python docstrings, Rust
+  doc-comments), and the English identifier names you choose for new functions, types, fields, files, and tests.
+- Localisation files (English source or English target): `.po`, `.pot`, `.properties`, `.resx`, `.json` (i18n), `.ftl`,
+  `.arb`.
+- UI strings: buttons, labels, placeholders, tooltips, empty states, confirmations.
+- Error, validation, warning, and log messages (including one-line `msgid` / `msgstr`).
+- Commit messages, PR / MR descriptions, code-review replies.
+
+Short messages count. A single `msgstr "..."` in a `.po` file, a one-line `// FIXME: …` comment in a `.go` file, or a
+three-word button label is in scope.
+
+### When NOT to invoke
+
+- *Existing* code identifiers, product names, CLI flags, file paths, environment variables — do not translate, restyle,
+  or rename them. (When you *choose* a new identifier name, that choice is in scope; see *Covered surfaces*.)
+- Generated API references and verbatim third-party quotes.
+- Files explicitly marked "do not edit" or covered by a repository-specific style guide — yield to the local guide.
+- Casual chat replies to the user.
+
+### Failure mode to avoid
+
+If the request touches English text and the skill has not been invoked, stop and invoke it before continuing.
+Native-speaker intuition is not a substitute: the dialect policy, AI-tell catalogue, em-dash and hyphen rules, hedging
+policy, and per-surface templates live in the skill, not in general fluency.

--- a/.github/instructions/github-ticket-implementation-planner.instructions.md
+++ b/.github/instructions/github-ticket-implementation-planner.instructions.md
@@ -1,0 +1,7 @@
+---
+description: Plan implementation from a GitHub issue with clarifying questions and approved plan posting.
+applyTo: "**"
+---
+
+When planning implementation from a GitHub issue, ticket, or task description, apply the
+`github-ticket-implementation-planner` skill.

--- a/.github/instructions/go-comments.instructions.md
+++ b/.github/instructions/go-comments.instructions.md
@@ -1,0 +1,21 @@
+---
+description: Go comment policy and entity-to-view converter naming
+applyTo: "**/*.go"
+---
+
+# Go Comments and Converters
+
+## Comments
+
+- Comment only when it materially helps understanding non-obvious logic.
+- Do not comment obvious code.
+- Do not add comments that map structs/functions to HTTP routes (e.g. `// AiChatsListResponse is GET /chats`).
+
+## CI / EditorConfig in Go sources
+
+- Raw string literals (system prompts, embedded templates): continuation lines that look indented must use **tabs**, not spaces — see CI linter rules.
+
+## Entity → view converters
+
+- Converters with **no dependencies** belong in the `entity` package next to the entity struct.
+- Name them `Make{Name}View` (e.g. `MakePackageSearchResultView`).

--- a/.github/instructions/go-constants-and-http.instructions.md
+++ b/.github/instructions/go-constants-and-http.instructions.md
@@ -1,0 +1,18 @@
+---
+description: Go constants, literals, and HTTP status code conventions
+applyTo: "**/*.go"
+---
+
+# Go Constants and HTTP Status
+
+## Constants and literals
+
+- Do not use magic numbers; declare named constants.
+- If a numeric literal is unavoidable, add a brief comment explaining what it is and why that value is used.
+- If a string literal is repeated, extract it to a constant.
+- Do **not** duplicate config defaults in service code. Defaults belong in centralized config initialization; valid ranges belong on config struct fields via validation tags checked at startup. Services read validated config directly — no `if cfg.X <= 0 { fallback }` for config-backed values.
+
+## HTTP status codes
+
+- Use `net/http` named constants (`http.StatusOK`, `http.StatusBadRequest`, `http.StatusNotFound`, etc.).
+- Do not use raw status integers (e.g. `200`, `400`, `404`) in handlers, middleware, or tests.

--- a/.github/instructions/go-error-handling.instructions.md
+++ b/.github/instructions/go-error-handling.instructions.md
@@ -1,0 +1,12 @@
+---
+description: Go error handling — fail fast and fix root cause
+applyTo: "**/*.go"
+---
+
+# Go Error Handling
+
+- **Bugfixes:** investigate and fix the **root cause**; do not patch symptoms by swallowing errors or forcing default behavior when something failed.
+- **Do not:** `_ = err`; `return nil` / empty data after a failed DB or external call; `log` then continue as if success; catch-all `recover()` without re-panic or proper fatal handling; widen `if err != nil` to ignore and use a zero value unless product spec requires it.
+- **Do:** return `error` from lower layers; handle once at the boundary (controller / job) with proper API error codes and ERROR-level logs.
+- **Fail fast** on misconfiguration and fatal wiring (`log.Fatalf` in service entry files, config validation at startup).
+- Intentional degradation only with explicit product requirement — log the failure and document the fallback.

--- a/.github/instructions/go-migrations.instructions.md
+++ b/.github/instructions/go-migrations.instructions.md
@@ -1,0 +1,11 @@
+---
+description: SQL migration numbering and file conventions
+applyTo: "**/resources/migrations/**"
+---
+
+# Database Migrations
+
+- Use the next unused numeric prefix (check the migrations directory for the current highest).
+- **Never** reuse or duplicate migration numbers.
+- Provide paired `.up.sql` and `.down.sql` files when rollback is required.
+- After adding migrations, run the repository's migration validation script if one is provided (see the repo-specific developer skill).

--- a/.github/instructions/sql-performance.instructions.md
+++ b/.github/instructions/sql-performance.instructions.md
@@ -1,0 +1,14 @@
+---
+description: SQL performance review for repository changes
+applyTo: "**/repository/**"
+---
+
+# SQL Performance
+
+When adding or changing non-trivial SQL in repositories:
+
+- Consider required indices for filters, joins, and sort columns.
+- Avoid N+1 query patterns; prefer joins or batch loads where appropriate.
+- Note expected cardinality (rows scanned/returned) for hot paths.
+- Flag full table scans, missing indices, and unbounded result sets.
+- Document performance assumptions in the PR or commit message when risk is non-obvious.

--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -21,6 +21,11 @@ VALIDATE_PYTHON_PYLINT=false
 
 # APIHUB CUSTOM
 
+# APM-deployed agent harness (upstream packages under .cursor/.claude/.agents)
+FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)
+MARKDOWN_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)
+NATURAL_LANGUAGE_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)
+
 # Go linter has a bug and doesn't work fine
 VALIDATE_GO=false
 VALIDATE_GO_MODULES=false

--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -21,10 +21,10 @@ VALIDATE_PYTHON_PYLINT=false
 
 # APIHUB CUSTOM
 
-# APM-deployed agent harness (upstream packages under .cursor/.claude/.agents)
-FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)
-MARKDOWN_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)
-NATURAL_LANGUAGE_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)
+# APM-deployed agent harness (upstream packages; not repo-authored)
+FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
+MARKDOWN_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
+NATURAL_LANGUAGE_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
 
 # Go linter has a bug and doesn't work fine
 VALIDATE_GO=false

--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -21,10 +21,10 @@ VALIDATE_PYTHON_PYLINT=false
 
 # APIHUB CUSTOM
 
-# APM-deployed agent harness (upstream packages; not repo-authored)
-FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
-MARKDOWN_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
-NATURAL_LANGUAGE_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)
+# APM agent content (deployed harness + local package sources + compiled agent docs)
+FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)|(/|^)agent-packages(/|$)|(/|^)(AGENTS|GEMINI|CLAUDE)\.md$
+MARKDOWN_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)|(/|^)agent-packages(/|$)|(/|^)(AGENTS|GEMINI|CLAUDE)\.md$
+NATURAL_LANGUAGE_FILTER_REGEX_EXCLUDE=(/|^)\.(cursor|claude|agents)(/|$)|(/|^)\.github/(instructions|skills|prompts)(/|$)|(/|^)agent-packages(/|$)|(/|^)(AGENTS|GEMINI|CLAUDE)\.md$
 
 # Go linter has a bug and doesn't work fine
 VALIDATE_GO=false

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -19,6 +19,16 @@ jobs:
         with:
           args: >-
             './**/*.md'
+            --exclude-path '.cursor/**'
+            --exclude-path '.claude/**'
+            --exclude-path '.agents/**'
+            --exclude-path '.github/instructions/**'
+            --exclude-path '.github/skills/**'
+            --exclude-path '.github/prompts/**'
+            --exclude-path 'agent-packages/**'
+            --exclude-path 'AGENTS.md'
+            --exclude-path 'GEMINI.md'
+            --exclude-path 'CLAUDE.md'
             --verbose
             --no-progress
             --user-agent 'Mozilla/5.0 (X11; Linux x86_64) Chrome/134.0.0.0'

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,5 @@ go.sum
 api-linter-service/*debug*.exe
 api-linter-service/tmp
 
-# APM dependencies and deployed agent context
+# APM cache (installed package sources)
 apm_modules/
-.cursor/skills/
-.cursor/rules/
-.claude/skills/
-.claude/rules/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@
 go.sum
 api-linter-service/*debug*.exe
 api-linter-service/tmp
+
+# APM dependencies and deployed agent context
+apm_modules/
+.cursor/skills/
+.cursor/rules/
+.claude/skills/
+.claude/rules/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,7 @@
 ^.*example.com
 ^.*xmlsoap.org
+
+# APM-deployed agent harness (upstream package markdown)
+^\.cursor/
+^\.claude/
+^\.agents/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -5,3 +5,6 @@
 ^\.cursor/
 ^\.claude/
 ^\.agents/
+^\.github/instructions/
+^\.github/skills/
+^\.github/prompts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,186 @@
+# APIHub Linter Service — Agent Instructions
+
+Instructions for AI assistants working on **qubership-api-linter-service** (Cursor, Claude Code, and compatible tools).
+
+This microservice lints API specifications (OpenAPI / AsyncAPI) for the APIHUB platform, stores results in PostgreSQL, exposes REST endpoints for validation summaries and scoring, and reacts to version-publication events from the main backend via Olric.
+
+## Clarification before coding
+
+- Do **not** generate or modify code until the task requirements are clear.
+- Ask targeted questions when scope, behavior, acceptance criteria, or API contract is ambiguous.
+- For GitHub ticket work, use the project skill `github-ticket-implementation-planner` before implementation.
+- If you must assume something, state assumptions explicitly and keep changes minimal until confirmed.
+
+## Error handling: fail fast, fix root cause (not symptoms)
+
+Applies to **bug fixes and new features**.
+
+### Bug fixes
+
+- **Find and fix the root cause** — trace the failure (logs, stack, task pipeline, APIHUB client response, linter subprocess output). Do not mask symptoms.
+- **Forbidden as a “fix”** unless the user explicitly requests a temporary workaround and documents it:
+  - Swallowing errors (`_ = err`, ignored `err`, empty result after failed DB/API/subprocess calls).
+  - Silent fallbacks when linting, scoring, or task processing failed (pretend success, skip persistence, return cached stale data without indication).
+  - Broad `recover()` or generic handlers that hide the real failure.
+
+### New code and refactors
+
+- **Propagate errors** from repositories and services; map to HTTP at the controller boundary.
+- Use **`exception.CustomError`** for client-facing API errors (see **API errors** below). Use plain `error` for internal layers when the controller already translates failures.
+- **Fail fast** on fatal startup wiring (`log.Fatalf` / `panic` patterns already used in `service.go` for migration failure, missing Spectral binary, auth setup, etc.).
+- **Log errors** at ERROR for unrecoverable failures; DEBUG for expected client errors passed through `RespondWithCustomError`.
+- Background workers (`DocTaskProcessor`, `VersionTaskProcessor`) must mark tasks failed in DB and log the cause — do not leave tasks stuck in an ambiguous state without logging.
+
+### Before submitting a bug-fix diff
+
+Briefly state: **root cause**, **why the change fixes it**, and confirm you did **not** add swallow-and-continue logic.
+
+## Libraries and dependencies
+
+- Do **not** reimplement functionality available in established libraries already used here (gorilla/mux, go-pg, logrus, resty, OpenAI SDK, Spectral CLI integration patterns).
+- Prefer existing executors (`SpectralExecutor`, `AiOasExecutor`) and repository patterns over ad-hoc DB or HTTP code.
+- Justify any **new** Go module dependency briefly.
+
+## GitHub CLI
+
+- Use **`gh`** for issues, pull requests, checks, and releases.
+- If `gh` is missing or not authenticated, tell the user — do not scrape GitHub HTML.
+
+## Cross-platform development (Windows + Linux)
+
+- Team uses **Linux** and **Windows (often with WSL)**.
+- Go module and runnable binary live under `qubership-api-linter-service/`; run `go test` / `go build` from that directory unless the task says otherwise.
+- Spectral/Vacuum bundled binaries exist under `resources/spectral/` and `resources/vacuum/` per OS — respect platform paths when touching executor code.
+- Prefer repo-relative paths like `qubership-api-linter-service/controller/...`.
+
+## Related repositories
+
+| Repo | Relationship |
+|------|----------------|
+| **qubership-apihub-backend** | Runtime dependency — fetches packages, versions, documents, auth via `client/apihub.go` (`APIHUB_URL`, `APIHUB_ACCESS_TOKEN`). REST contract changes there may require linter client or behaviour updates. |
+| **qubership-apihub-ui** | Consumes linter REST endpoints for validation summaries and scoring in the portal. |
+| **qubership-apihub-ci** | Shared super-linter workflows and generic agent skills (`agent-skills/`). |
+
+When a change affects REST contracts or integration behaviour, **remind** the developer if follow-up is needed in backend or UI — this workspace may not contain those repos.
+
+## Repository layout
+
+| Area | Location |
+|------|----------|
+| Entry point / route registration | `qubership-api-linter-service/service.go` |
+| HTTP controllers | `qubership-api-linter-service/controller/` |
+| Business logic | `qubership-api-linter-service/service/` |
+| Data access | `qubership-api-linter-service/repository/` |
+| DB entities | `qubership-api-linter-service/entity/` |
+| API DTOs / enums (`Linter`, `ApiType`, …) | `qubership-api-linter-service/view/` |
+| API error codes | `qubership-api-linter-service/exception/errors.go` |
+| APIHUB HTTP client | `qubership-api-linter-service/client/apihub.go` |
+| Auth middleware | `qubership-api-linter-service/security/` |
+| SQL migrations | `qubership-api-linter-service/resources/migrations/` |
+| Default Spectral/Vacuum rules | `qubership-api-linter-service/resources/spectral/`, `.../vacuum/` |
+| OpenAPI specs (this service) | `docs/api/linter_service_api.yaml`, `docs/api/admin_api.yaml` |
+| Architecture notes | `docs/arch_proposal/`, `docs/validation_sequence/` |
+
+## Domain model (read before changing lint flow)
+
+### Validation pipeline
+
+1. **Trigger** — POST validation, bulk validation, or Olric `"version-published"` event (`PublishEventListener`).
+2. **Version task** — `VersionTaskProcessor` loads documents from APIHUB, creates per-document lint tasks per enabled linter/ruleset.
+3. **Document task** — `DocTaskProcessor` worker pool downloads raw spec, runs Spectral and/or AI linter, caches by content hash + ruleset, persists results.
+4. **Scoring** — after version lint completes, `ScoringService` may compute version-level quality score (see `service/scoring.go`).
+
+### Linter engines
+
+| Engine | Code | API types | Notes |
+|--------|------|-----------|-------|
+| Spectral | `view.SpectralLinter` | OpenAPI 2.0/3.0/3.1, AsyncAPI 3.0 | Subprocess via `SPECTRAL_BIN_PATH`; concurrency via worker count |
+| AI linter | `view.AiLinter` | OpenAPI 2.0/3.0/3.1 only | Opt-in via `ENABLE_AI_OAS_LINTER`; OpenAI rate limits apply |
+
+Registration lives in `service/linter_config.go`; selection in `service/linter_selector.go`; execution branch in `service/doc_task_processor.go`.
+
+### Adding a new linter engine
+
+1. Add `Linter` constant in `view/linter.go`.
+2. Register in `linter_config.go` `loadInternalConfigs()` (API types, workers, enable flag).
+3. Implement executor (mirror `spectral_executor.go` or `ai_oas_executor.go`).
+4. Wire into `doc_task_processor.go` `processDocTask()`.
+5. Extend validation summary/detail mapping in `service/validation.go` if output shape differs.
+6. Update OpenAPI under `docs/api/` if new REST surface is exposed.
+
+### Adding a new API type
+
+1. Add `ApiType` in `view/document.go`.
+2. Attach to relevant linter configs in `linter_config.go`.
+3. Add or extend Spectral rules under `resources/spectral/rules/` when applicable.
+
+## Go coding conventions (summary)
+
+Detailed rules apply via deployed `.cursor/rules/` and `.claude/rules/` (from APM). Key points for **this** repo:
+
+- **No magic numbers** — named constants; brief comment if a literal is unavoidable.
+- **HTTP status codes** — use `net/http` constants, not raw integers.
+- **Repeated strings** — extract to constants (especially error codes/messages).
+- **Comments** — only for non-obvious logic; do not map types to HTTP routes in comments.
+- **Entity → view converters** without dependencies: `Make{Name}View` in `entity/` next to the struct.
+- **Wiring in `service.go`** — follow existing order: repositories → services → background processors → controllers → routes. Use `log.Fatalf` for fatal init errors consistent with surrounding code.
+- **API errors** — client-facing codes and messages as constants in `exception/errors.go`, returned via `exception.CustomError` with `Status`, `Code`, `Message`, optional `Params` (placeholders like `$id`, `$param`), and `Debug` for internal detail. Reuse existing codes (`EntityNotFound`, `LintNotSupported`, `InvalidParameterValue`, …) before inventing new ones.
+
+## REST API and OpenAPI
+
+- Follow **API-first**: update `docs/api/linter_service_api.yaml` (and `admin_api.yaml` if admin endpoints change) when REST contract changes.
+- Prefer **v2** endpoints for new summary/detail behaviour; v1 paths marked deprecated in code — do not extend deprecated handlers unless fixing a bug.
+- Service exposes its own specs via api-spec-exposer from `API_SPEC_DIR` (see `service.go` discovery block).
+- Avoid breaking public API changes without explicit product approval.
+
+## Database migrations
+
+- Files: `qubership-api-linter-service/resources/migrations/`.
+- Use the next unused numeric prefix; **no duplicate numbers**.
+- Provide paired `.up.sql` and `.down.sql` when rollback is required.
+- Migrations run at startup via `DBMigrationService` before the main server accepts traffic.
+
+## Rulesets and bundled linter config
+
+- Custom rulesets: uploaded via REST (`POST /api/v1/rulesets`), stored in DB, activated per API type.
+- Default Spectral rules: `resources/spectral/rules/rules.yaml` (extends `spectral:oas` recommended).
+- Changing default rules affects all deployments — treat as product-visible behaviour.
+
+## CI linters (super-linter / link checker)
+
+PRs run **super-linter** (see `.github/workflows/super-linter.yaml`) and **lychee** on Markdown. While writing:
+
+- **Go:** tabs in `*.go`; tabs inside raw string literals for nested indentation.
+- **Markdown:** prose lines ≤ **400** characters; one H1 per file.
+- **OpenAPI YAML:** no trailing whitespace on changed lines; match existing indentation.
+- **Links:** repo-relative paths must resolve from the editing file.
+
+Full checklist: `.cursor/rules/ci-super-linter.mdc` after `apm install`.
+
+## SQL performance
+
+- For non-trivial repository SQL: consider indexes, join cardinality, N+1 patterns, and unbounded result sets (task queues, result aggregation).
+
+## Testing and verification
+
+- Run targeted tests: `go test ./...` from `qubership-api-linter-service/`.
+- For lint executor changes, consider unit tests with fixture specs; integration tests may require Spectral binary and DB.
+- After REST changes, sanity-check OpenAPI parity with registered routes in `service.go`.
+
+## Completion
+
+- After substantive changes, propose **one** concise conventional-commit message.
+- For an independent review, invoke `apihub-go-self-review` in a **new chat** or with a **different model**.
+
+## Project skills (Cursor / Claude)
+
+Generic skills and rules are provisioned by APM from the
+[CI store](https://github.com/Netcracker/qubership-apihub-ci/tree/main/agent-skills):
+
+```bash
+apm install --target cursor,claude --legacy-skill-paths
+```
+
+Skills auto-discover from `.cursor/skills/` and `.claude/skills/` (`apihub-go-developer`, `apihub-go-self-review`, `github-ticket-implementation-planner`). See [README — AI agent configuration (APM)](README.md#ai-agent-configuration-apm).
+
+Repo-specific agent packages are **not** used here — only generic CI packages apply.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Briefly state: **root cause**, **why the change fixes it**, and confirm you did 
 |------|----------------|
 | **qubership-apihub-backend** | Runtime dependency — fetches packages, versions, documents, auth via `client/apihub.go` (`APIHUB_URL`, `APIHUB_ACCESS_TOKEN`). REST contract changes there may require linter client or behaviour updates. |
 | **qubership-apihub-ui** | Consumes linter REST endpoints for validation summaries and scoring in the portal. |
-| **qubership-apihub-ci** | Shared super-linter workflows and generic agent skills (`agent-skills/`). |
+| **qubership-apihub-ci** | Shared super-linter workflows and generic agent packages (`agent-packages/`). |
 
 When a change affects REST contracts or integration behaviour, **remind** the developer if follow-up is needed in backend or UI — this workspace may not contain those repos.
 
@@ -175,7 +175,7 @@ Full checklist: `.cursor/rules/ci-super-linter.mdc` after `apm install`.
 ## Project skills (Cursor / Claude)
 
 Generic skills and rules are provisioned by APM from the
-[CI store](https://github.com/Netcracker/qubership-apihub-ci/tree/main/agent-skills):
+[CI store](https://github.com/Netcracker/qubership-apihub-ci/tree/main/agent-packages):
 
 ```bash
 apm install --target cursor,claude --legacy-skill-paths

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# APIHub linter service (Claude Code)
+
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # qubership-api-linter-service
 The qubership-api-linter-service is a Golang-based microservice that provides a REST API endpoint for linting and validating OpenAPI Specification (OAS) files. It serves as a quality control tool for API definitions, helping developers maintain consistency and adhere to best practices in their API documentation.
 
-# Key Features
+## Key Features
 
 Dual-engine support (Spectral and Vacuum) for comprehensive OAS validation
 
@@ -9,14 +9,17 @@ RESTful interface for easy integration into CI/CD pipelines
 
 Lightweight container-friendly design
 
-# Current Status:
+## Current Status
+
 ⚠️ Development Preview
 This service is currently under active development and not yet recommended for production use. The team is working on additional features and stability improvements.
 
-# Installation:
+## Installation
+
 Installation instructions will be provided in future releases (TODO).
 
-# Build Instructions:
+## Build Instructions
+
 To compile the service, simply execute the appropriate build script:
 
 Windows: build.cmd
@@ -28,7 +31,7 @@ The build process generates a standalone binary with all required dependencies. 
 ## AI agent configuration (APM)
 
 Agent skills and rules for this repository are distributed from the central store in
-[`qubership-apihub-ci/agent-skills`](https://github.com/Netcracker/qubership-apihub-ci/tree/main/agent-skills)
+[`qubership-apihub-ci`](https://github.com/Netcracker/qubership-apihub-ci) (`agent-skills/`)
 using [APM](https://microsoft.github.io/apm/). They are **not** committed here; run APM
 after cloning to populate `.cursor/` and `.claude/`:
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,21 @@ Windows: build.cmd
 Linux/macOS: build.sh
 
 The build process generates a standalone binary with all required dependencies. Future versions will include containerization support and package management options.
+
+## AI agent configuration (APM)
+
+Agent skills and rules for this repository are distributed from the central store in
+[`qubership-apihub-ci/agent-skills`](https://github.com/Netcracker/qubership-apihub-ci/tree/main/agent-skills)
+using [APM](https://microsoft.github.io/apm/). They are **not** committed here; run APM
+after cloning to populate `.cursor/` and `.claude/`:
+
+```bash
+# one-time: install APM (see https://microsoft.github.io/apm/)
+brew install microsoft/apm/apm   # or: pip install apm-cli
+
+# from the repository root:
+apm install --target cursor,claude --legacy-skill-paths
+```
+
+This reads `apm.yml`, pins versions in `apm.lock.yaml`, and deploys the skills/rules into
+`.cursor/` and `.claude/`. To update, re-run `apm install`.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ The build process generates a standalone binary with all required dependencies. 
 
 ## AI agent configuration (APM)
 
-Agent skills and rules for this repository are distributed from the central store in
-[`qubership-apihub-ci`](https://github.com/Netcracker/qubership-apihub-ci) (`agent-skills/`)
-using [APM](https://microsoft.github.io/apm/). They are **not** committed here; run APM
-after cloning to populate `.cursor/` and `.claude/`:
+Generic agent packages come from [`qubership-apihub-ci/agent-packages`](https://github.com/Netcracker/qubership-apihub-ci/tree/main/agent-packages)
+via [APM](https://microsoft.github.io/apm/). Deployed `.cursor/` and `.claude/` harness trees are
+**committed**; refresh them after changing `apm.yml` or upstream packages:
 
 ```bash
 # one-time: install APM (see https://microsoft.github.io/apm/)
@@ -43,5 +42,6 @@ brew install microsoft/apm/apm   # or: pip install apm-cli
 apm install --target cursor,claude --legacy-skill-paths
 ```
 
-This reads `apm.yml`, pins versions in `apm.lock.yaml`, and deploys the skills/rules into
-`.cursor/` and `.claude/`. To update, re-run `apm install`.
+This reads `apm.yml`, updates `apm.lock.yaml`, and deploys skills/rules into `.cursor/` and
+`.claude/`. Commit the refreshed harness trees with manifest or lockfile changes. Only
+`apm_modules/` is gitignored.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,100 +1,123 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T10:57:17.732907+00:00'
+generated_at: '2026-06-03T14:56:35.765803+00:00'
 apm_version: 0.16.0
 dependencies:
 - repo_url: Netcracker/qubership-ai-packages
   host: github.com
-  resolved_commit: 3024f029cbc9042d6905037d2fa0a98e7b6e27f2
-  resolved_ref: v1.0.1
+  resolved_commit: 785ac701be71e5f09f8857970c026d5f6bbbbb1a
   virtual_path: agent-packages/english-developer-style
   is_virtual: true
   package_type: apm_package
   deployed_files:
+  - .agents/skills/english-developer-style
   - .claude/rules/english-developer-style.md
   - .claude/skills/english-developer-style
   - .cursor/rules/english-developer-style.mdc
-  - .cursor/skills/english-developer-style
+  - .github/instructions/english-developer-style.instructions.md
   deployed_file_hashes:
     .claude/rules/english-developer-style.md: sha256:71d5921cbb7e91db77b2ad7403714cc4d8471e3af7a974b850e9831df2ca25b9
     .cursor/rules/english-developer-style.mdc: sha256:981d72b4b97f7b5fb861ea9beb32edef5746c8ed87419abaadc999e14861a6a9
+    .github/instructions/english-developer-style.instructions.md: sha256:9bd3f0ea1da9c84677b4d7e91126208b437bc93b82ea6c684e1d76db9e42abde
   content_hash: sha256:107dd671a330a3afcb3bcce940afa130f5576c17840cee77d9fcefeb4550c68c
 - repo_url: _local/apihub-go-developer
   package_type: apm_package
   deployed_files:
+  - .agents/skills/apihub-go-developer
   - .claude/rules/apihub-go-developer.md
   - .claude/skills/apihub-go-developer
   - .cursor/rules/apihub-go-developer.mdc
-  - .cursor/skills/apihub-go-developer
+  - .github/instructions/apihub-go-developer.instructions.md
   deployed_file_hashes:
     .claude/rules/apihub-go-developer.md: sha256:a7ab06cdc6e814ed225065319e1cd20270dee2172ea41d0b1124ff84fc6bf799
     .cursor/rules/apihub-go-developer.mdc: sha256:bf6ce2a6cc2faea88310673288176fd37c172266b070eb761dd924e99cfa01e3
+    .github/instructions/apihub-go-developer.instructions.md: sha256:ef1557c50549af71a9a6384c6a25483e4a69f5ce5429384357b21d3b3818e495
   source: local
-  local_path: c:\sources\GIT\Github\APIHUB-ALL\qubership-apihub-ci\agent-packages/apihub-go-developer
+  local_path: ../qubership-apihub-ci/agent-packages/apihub-go-developer
 - repo_url: _local/apihub-go-self-review
   package_type: apm_package
   deployed_files:
+  - .agents/skills/apihub-go-self-review
   - .claude/rules/apihub-go-self-review.md
   - .claude/skills/apihub-go-self-review
   - .cursor/rules/apihub-go-self-review.mdc
-  - .cursor/skills/apihub-go-self-review
+  - .github/instructions/apihub-go-self-review.instructions.md
   deployed_file_hashes:
     .claude/rules/apihub-go-self-review.md: sha256:09190a6cb552a30eaa215473633f833eb9fe6c6852c679c552f799b910f3031b
     .cursor/rules/apihub-go-self-review.mdc: sha256:bec195119cfd4aaff319c0f54d1b4445d8d9b082bd4a7a932420efcaa309eb27
+    .github/instructions/apihub-go-self-review.instructions.md: sha256:ca5b2d888ed042eed2c904d5d68ae74df7435204409a3ba08dbbde3db8756951
   source: local
-  local_path: c:\sources\GIT\Github\APIHUB-ALL\qubership-apihub-ci\agent-packages/apihub-go-self-review
-- repo_url: _local/common-conventions
+  local_path: ../qubership-apihub-ci/agent-packages/apihub-go-self-review
+- repo_url: _local/development-conventions
   package_type: apm_package
   deployed_files:
+  - .claude/rules/ci-super-linter.md
   - .claude/rules/clarify-before-coding.md
+  - .cursor/rules/ci-super-linter.mdc
   - .cursor/rules/clarify-before-coding.mdc
+  - .github/instructions/ci-super-linter.instructions.md
+  - .github/instructions/clarify-before-coding.instructions.md
   deployed_file_hashes:
+    .claude/rules/ci-super-linter.md: sha256:d655a548333e52a748113632665f810e3fb6084339852306aca90f02cfb4f0c7
     .claude/rules/clarify-before-coding.md: sha256:a3e34e5277a4a3fba12fd6f236e921a59c561e6ee82e240eec247861aa8a398c
+    .cursor/rules/ci-super-linter.mdc: sha256:2f264db238d0d7ffd9d8b830dd383233c57b20e057557d65084fe3f0e7512967
     .cursor/rules/clarify-before-coding.mdc: sha256:ceb003b39ea330002556d10d3ca52445909bbaf23705ff27f2643705db98c0f4
+    .github/instructions/ci-super-linter.instructions.md: sha256:7e8e2395715e9bd69ec938d4e106ec16d0e9256053c1562cf915a40bf33c7fe5
+    .github/instructions/clarify-before-coding.instructions.md: sha256:f0723cdf5b2cc34bc46992a6c550842f8eb9dcc5b39540c9916835a4ee58d60d
   source: local
-  local_path: c:\sources\GIT\Github\APIHUB-ALL\qubership-apihub-ci\agent-packages/common-conventions
+  local_path: ../qubership-apihub-ci/agent-packages/development-conventions
 - repo_url: _local/github-ticket-implementation-planner
   package_type: apm_package
   deployed_files:
+  - .agents/skills/github-ticket-implementation-planner
   - .claude/rules/github-ticket-implementation-planner.md
   - .claude/skills/github-ticket-implementation-planner
   - .cursor/rules/github-ticket-implementation-planner.mdc
-  - .cursor/skills/github-ticket-implementation-planner
+  - .github/instructions/github-ticket-implementation-planner.instructions.md
   deployed_file_hashes:
     .claude/rules/github-ticket-implementation-planner.md: sha256:4e13f07f0749bcfd778fe44899221bff81152ee83a90b74fc7dcfafff838353c
     .cursor/rules/github-ticket-implementation-planner.mdc: sha256:67d9c2440bc50c68b21b1afd6aa25c0a8447db76bfa7c0a7898920a3cf297d20
+    .github/instructions/github-ticket-implementation-planner.instructions.md: sha256:e2770726d0d63444f1a2df2e848a46f29556cd638c22b5484bc21bdf5ac60264
   source: local
-  local_path: c:\sources\GIT\Github\APIHUB-ALL\qubership-apihub-ci\agent-packages/github-ticket-implementation-planner
+  local_path: ../qubership-apihub-ci/agent-packages/github-ticket-implementation-planner
 - repo_url: _local/go-conventions
   package_type: apm_package
   deployed_files:
   - .claude/rules/api-first-openapi.md
-  - .claude/rules/ci-super-linter.md
   - .claude/rules/go-comments.md
   - .claude/rules/go-constants-and-http.md
   - .claude/rules/go-error-handling.md
   - .claude/rules/go-migrations.md
   - .claude/rules/sql-performance.md
   - .cursor/rules/api-first-openapi.mdc
-  - .cursor/rules/ci-super-linter.mdc
   - .cursor/rules/go-comments.mdc
   - .cursor/rules/go-constants-and-http.mdc
   - .cursor/rules/go-error-handling.mdc
   - .cursor/rules/go-migrations.mdc
   - .cursor/rules/sql-performance.mdc
+  - .github/instructions/api-first-openapi.instructions.md
+  - .github/instructions/go-comments.instructions.md
+  - .github/instructions/go-constants-and-http.instructions.md
+  - .github/instructions/go-error-handling.instructions.md
+  - .github/instructions/go-migrations.instructions.md
+  - .github/instructions/sql-performance.instructions.md
   deployed_file_hashes:
     .claude/rules/api-first-openapi.md: sha256:2e28a945412a344a23f5900f4704ef6a6a7ceedb0c599056ba09e63432a7bab4
-    .claude/rules/ci-super-linter.md: sha256:61ba8e911259ed5a8f0d9a9c7d6762c694d9e231dfa4f498a7d67c276958cd36
     .claude/rules/go-comments.md: sha256:57c3326eed8a055caaad74c140917c078778ff04f562cba845d22df63e98b582
     .claude/rules/go-constants-and-http.md: sha256:f8d52303334e63092309d62e29085321b32a8bb8c4bce8ca38cd79af56f43a69
     .claude/rules/go-error-handling.md: sha256:61407348b5d86d8e2cf730816c13d04e7fdea3a20be38a5b3405b01a6ce71cb2
     .claude/rules/go-migrations.md: sha256:1d3e486379993f6fe68d2f4b53f3e2207154988a09b9c1c5ab98659a910edc88
     .claude/rules/sql-performance.md: sha256:d826f635a958a4e5295a5e3e30f9fe61844a77e987a6d474308083985a91c1af
     .cursor/rules/api-first-openapi.mdc: sha256:1ec7880c515db06e1d852395d7d8a5728bce08b20b9e1087115a03956d73bcb7
-    .cursor/rules/ci-super-linter.mdc: sha256:32577dcadb66177e4a61a592be195b01b4d13876d3928c69c024d7e563ab013a
     .cursor/rules/go-comments.mdc: sha256:f8e9df333a575ef38519b7415f0301235563fdd3dc18867b49dfbc8690de3fca
     .cursor/rules/go-constants-and-http.mdc: sha256:778efcf145d35ccc3314f68cf0d54e33c1f13ef0ba4a19e809b4b24be80fc9bb
     .cursor/rules/go-error-handling.mdc: sha256:9c084d61f2b27040a50c277a481232b00ecfd62b7b6da8b6aa7c86aaa184ba6c
     .cursor/rules/go-migrations.mdc: sha256:79ab6bc7ae81f74719b4ccfbc9b5ce2146ee7ef1c58f47031cf2a742a9765297
     .cursor/rules/sql-performance.mdc: sha256:b8748ddf13e089c63529ae6423a7fb930a8cfae4160c3366e276c6bf4fac5138
+    .github/instructions/api-first-openapi.instructions.md: sha256:a0fa42fb75fa89eac5e37da4d960015ee1bbb22b3a1fc4beb94007371de10176
+    .github/instructions/go-comments.instructions.md: sha256:87f198201fb384206af8d4e2827c53c7133fa3de4d5e267834e2f5f273ccf2b9
+    .github/instructions/go-constants-and-http.instructions.md: sha256:0854f8fba840ec10b8ddf51af627208801578ea419be6d2e3ff4faa51ea68640
+    .github/instructions/go-error-handling.instructions.md: sha256:f5d8a30e9ed725693ba229392fae6d77576cdb59c4e077070902062627814251
+    .github/instructions/go-migrations.instructions.md: sha256:3a1da7a929ec634031ca03eee095b3272c0e9d5216d579a46d95cf4b6fcf68fc
+    .github/instructions/sql-performance.instructions.md: sha256:7bbfae4b968dd1f2cc024d8e28bf5df5acc188ee24d53f460ab916f19f2df069
   source: local
-  local_path: c:\sources\GIT\Github\APIHUB-ALL\qubership-apihub-ci\agent-packages/go-conventions
+  local_path: ../qubership-apihub-ci/agent-packages/go-conventions

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,0 +1,100 @@
+lockfile_version: '1'
+generated_at: '2026-06-03T10:57:17.732907+00:00'
+apm_version: 0.16.0
+dependencies:
+- repo_url: Netcracker/qubership-ai-packages
+  host: github.com
+  resolved_commit: 3024f029cbc9042d6905037d2fa0a98e7b6e27f2
+  resolved_ref: v1.0.1
+  virtual_path: agent-packages/english-developer-style
+  is_virtual: true
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/english-developer-style.md
+  - .claude/skills/english-developer-style
+  - .cursor/rules/english-developer-style.mdc
+  - .cursor/skills/english-developer-style
+  deployed_file_hashes:
+    .claude/rules/english-developer-style.md: sha256:71d5921cbb7e91db77b2ad7403714cc4d8471e3af7a974b850e9831df2ca25b9
+    .cursor/rules/english-developer-style.mdc: sha256:981d72b4b97f7b5fb861ea9beb32edef5746c8ed87419abaadc999e14861a6a9
+  content_hash: sha256:107dd671a330a3afcb3bcce940afa130f5576c17840cee77d9fcefeb4550c68c
+- repo_url: _local/apihub-go-developer
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/apihub-go-developer.md
+  - .claude/skills/apihub-go-developer
+  - .cursor/rules/apihub-go-developer.mdc
+  - .cursor/skills/apihub-go-developer
+  deployed_file_hashes:
+    .claude/rules/apihub-go-developer.md: sha256:a7ab06cdc6e814ed225065319e1cd20270dee2172ea41d0b1124ff84fc6bf799
+    .cursor/rules/apihub-go-developer.mdc: sha256:bf6ce2a6cc2faea88310673288176fd37c172266b070eb761dd924e99cfa01e3
+  source: local
+  local_path: c:\sources\GIT\Github\APIHUB-ALL\qubership-apihub-ci\agent-packages/apihub-go-developer
+- repo_url: _local/apihub-go-self-review
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/apihub-go-self-review.md
+  - .claude/skills/apihub-go-self-review
+  - .cursor/rules/apihub-go-self-review.mdc
+  - .cursor/skills/apihub-go-self-review
+  deployed_file_hashes:
+    .claude/rules/apihub-go-self-review.md: sha256:09190a6cb552a30eaa215473633f833eb9fe6c6852c679c552f799b910f3031b
+    .cursor/rules/apihub-go-self-review.mdc: sha256:bec195119cfd4aaff319c0f54d1b4445d8d9b082bd4a7a932420efcaa309eb27
+  source: local
+  local_path: c:\sources\GIT\Github\APIHUB-ALL\qubership-apihub-ci\agent-packages/apihub-go-self-review
+- repo_url: _local/common-conventions
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/clarify-before-coding.md
+  - .cursor/rules/clarify-before-coding.mdc
+  deployed_file_hashes:
+    .claude/rules/clarify-before-coding.md: sha256:a3e34e5277a4a3fba12fd6f236e921a59c561e6ee82e240eec247861aa8a398c
+    .cursor/rules/clarify-before-coding.mdc: sha256:ceb003b39ea330002556d10d3ca52445909bbaf23705ff27f2643705db98c0f4
+  source: local
+  local_path: c:\sources\GIT\Github\APIHUB-ALL\qubership-apihub-ci\agent-packages/common-conventions
+- repo_url: _local/github-ticket-implementation-planner
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/github-ticket-implementation-planner.md
+  - .claude/skills/github-ticket-implementation-planner
+  - .cursor/rules/github-ticket-implementation-planner.mdc
+  - .cursor/skills/github-ticket-implementation-planner
+  deployed_file_hashes:
+    .claude/rules/github-ticket-implementation-planner.md: sha256:4e13f07f0749bcfd778fe44899221bff81152ee83a90b74fc7dcfafff838353c
+    .cursor/rules/github-ticket-implementation-planner.mdc: sha256:67d9c2440bc50c68b21b1afd6aa25c0a8447db76bfa7c0a7898920a3cf297d20
+  source: local
+  local_path: c:\sources\GIT\Github\APIHUB-ALL\qubership-apihub-ci\agent-packages/github-ticket-implementation-planner
+- repo_url: _local/go-conventions
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/api-first-openapi.md
+  - .claude/rules/ci-super-linter.md
+  - .claude/rules/go-comments.md
+  - .claude/rules/go-constants-and-http.md
+  - .claude/rules/go-error-handling.md
+  - .claude/rules/go-migrations.md
+  - .claude/rules/sql-performance.md
+  - .cursor/rules/api-first-openapi.mdc
+  - .cursor/rules/ci-super-linter.mdc
+  - .cursor/rules/go-comments.mdc
+  - .cursor/rules/go-constants-and-http.mdc
+  - .cursor/rules/go-error-handling.mdc
+  - .cursor/rules/go-migrations.mdc
+  - .cursor/rules/sql-performance.mdc
+  deployed_file_hashes:
+    .claude/rules/api-first-openapi.md: sha256:2e28a945412a344a23f5900f4704ef6a6a7ceedb0c599056ba09e63432a7bab4
+    .claude/rules/ci-super-linter.md: sha256:61ba8e911259ed5a8f0d9a9c7d6762c694d9e231dfa4f498a7d67c276958cd36
+    .claude/rules/go-comments.md: sha256:57c3326eed8a055caaad74c140917c078778ff04f562cba845d22df63e98b582
+    .claude/rules/go-constants-and-http.md: sha256:f8d52303334e63092309d62e29085321b32a8bb8c4bce8ca38cd79af56f43a69
+    .claude/rules/go-error-handling.md: sha256:61407348b5d86d8e2cf730816c13d04e7fdea3a20be38a5b3405b01a6ce71cb2
+    .claude/rules/go-migrations.md: sha256:1d3e486379993f6fe68d2f4b53f3e2207154988a09b9c1c5ab98659a910edc88
+    .claude/rules/sql-performance.md: sha256:d826f635a958a4e5295a5e3e30f9fe61844a77e987a6d474308083985a91c1af
+    .cursor/rules/api-first-openapi.mdc: sha256:1ec7880c515db06e1d852395d7d8a5728bce08b20b9e1087115a03956d73bcb7
+    .cursor/rules/ci-super-linter.mdc: sha256:32577dcadb66177e4a61a592be195b01b4d13876d3928c69c024d7e563ab013a
+    .cursor/rules/go-comments.mdc: sha256:f8e9df333a575ef38519b7415f0301235563fdd3dc18867b49dfbc8690de3fca
+    .cursor/rules/go-constants-and-http.mdc: sha256:778efcf145d35ccc3314f68cf0d54e33c1f13ef0ba4a19e809b4b24be80fc9bb
+    .cursor/rules/go-error-handling.mdc: sha256:9c084d61f2b27040a50c277a481232b00ecfd62b7b6da8b6aa7c86aaa184ba6c
+    .cursor/rules/go-migrations.mdc: sha256:79ab6bc7ae81f74719b4ccfbc9b5ce2146ee7ef1c58f47031cf2a742a9765297
+    .cursor/rules/sql-performance.mdc: sha256:b8748ddf13e089c63529ae6423a7fb930a8cfae4160c3366e276c6bf4fac5138
+  source: local
+  local_path: c:\sources\GIT\Github\APIHUB-ALL\qubership-apihub-ci\agent-packages/go-conventions

--- a/apm.yml
+++ b/apm.yml
@@ -2,8 +2,10 @@ name: qubership-api-linter-service
 version: 0.0.0
 dependencies:
   apm:
-    - Netcracker/qubership-apihub-ci/agent-packages/skills/apihub-go-developer#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/skills/apihub-go-self-review#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/skills/github-ticket-implementation-planner#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/instructions/common-conventions#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/instructions/go-conventions#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-self-review#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/github-ticket-implementation-planner#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/common-conventions#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/go-conventions#apm_migration
+
+

--- a/apm.yml
+++ b/apm.yml
@@ -9,7 +9,7 @@ dependencies:
     - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer
     - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-self-review
     - Netcracker/qubership-apihub-ci/agent-packages/github-ticket-implementation-planner
-    - Netcracker/qubership-apihub-ci/agent-packages/common-conventions
+    - Netcracker/qubership-apihub-ci/agent-packages/development-conventions
     - Netcracker/qubership-apihub-ci/agent-packages/go-conventions
 
 

--- a/apm.yml
+++ b/apm.yml
@@ -1,11 +1,16 @@
 name: qubership-api-linter-service
 version: 0.0.0
+targets:
+  - cursor
+  - claude
 dependencies:
   apm:
+    - Netcracker/qubership-ai-packages/agent-packages/english-developer-style#v1.0.1
     - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer#apm_migration
     - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-self-review#apm_migration
     - Netcracker/qubership-apihub-ci/agent-packages/github-ticket-implementation-planner#apm_migration
     - Netcracker/qubership-apihub-ci/agent-packages/common-conventions#apm_migration
     - Netcracker/qubership-apihub-ci/agent-packages/go-conventions#apm_migration
+
 
 

--- a/apm.yml
+++ b/apm.yml
@@ -5,7 +5,7 @@ targets:
   - claude
 dependencies:
   apm:
-    - Netcracker/qubership-ai-packages/agent-packages/english-developer-style#v1.0.1
+    - Netcracker/qubership-ai-packages/agent-packages/english-developer-style
     - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer
     - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-self-review
     - Netcracker/qubership-apihub-ci/agent-packages/github-ticket-implementation-planner

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,9 @@
+name: qubership-api-linter-service
+version: 0.0.0
+dependencies:
+  apm:
+    - Netcracker/qubership-apihub-ci/agent-skills/skills/apihub-go-developer#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-skills/skills/apihub-go-self-review#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-skills/skills/github-ticket-implementation-planner#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-skills/instructions/common-conventions#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-skills/instructions/go-conventions#apm_migration

--- a/apm.yml
+++ b/apm.yml
@@ -2,8 +2,8 @@ name: qubership-api-linter-service
 version: 0.0.0
 dependencies:
   apm:
-    - Netcracker/qubership-apihub-ci/agent-skills/skills/apihub-go-developer#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-skills/skills/apihub-go-self-review#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-skills/skills/github-ticket-implementation-planner#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-skills/instructions/common-conventions#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-skills/instructions/go-conventions#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/skills/apihub-go-developer#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/skills/apihub-go-self-review#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/skills/github-ticket-implementation-planner#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/instructions/common-conventions#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/instructions/go-conventions#apm_migration

--- a/apm.yml
+++ b/apm.yml
@@ -6,11 +6,12 @@ targets:
 dependencies:
   apm:
     - Netcracker/qubership-ai-packages/agent-packages/english-developer-style#v1.0.1
-    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-self-review#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/github-ticket-implementation-planner#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/common-conventions#apm_migration
-    - Netcracker/qubership-apihub-ci/agent-packages/go-conventions#apm_migration
+    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-developer
+    - Netcracker/qubership-apihub-ci/agent-packages/apihub-go-self-review
+    - Netcracker/qubership-apihub-ci/agent-packages/github-ticket-implementation-planner
+    - Netcracker/qubership-apihub-ci/agent-packages/common-conventions
+    - Netcracker/qubership-apihub-ci/agent-packages/go-conventions
+
 
 
 


### PR DESCRIPTION
## Summary
- Add `apm.yml` with generic packages only (go-developer, go-self-review, planner, common/go conventions).
- Gitignore `apm_modules/` and deployed `.cursor/`/`.claude/` agent dirs; document `apm install` in README.

## Depends on
- Merge first: https://github.com/Netcracker/qubership-apihub-ci/pull/67

## Related PR
- Backend (full set): https://github.com/Netcracker/qubership-apihub-backend/pull/435

## Test plan
- [ ] After store PR merge: `apm install --target cursor,claude --legacy-skill-paths`
- [ ] Commit generated `apm.lock.yaml`; drop `#apm_migration` refs
- [ ] Confirm no backend-only skills or rules deployed