### PR TITLE
feat: secure TLS for HTTP clients (pairs with backend #456)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Note: this uses host platform for the build, and we ask go build to target the needed platform, so we do not spend time on qemu emulation when running "go build"
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.26.1-alpine3.23 as builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.26.1-alpine3.23 AS builder
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
@@ -26,7 +26,7 @@ WORKDIR /workspace/qubership-api-linter-service
 
 RUN GOSUMDB=off CGO_ENABLED=0 go mod tidy && go mod download && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build .
 
-FROM docker.io/alpine:3.23
+FROM ghcr.io/netcracker/qubership-core-base:2.3.3@sha256:1339716127a7d170ba307b89f3a933f5e09c447607c89e16bf8d5a379db4e1f6
 
 ARG GIT_BRANCH=unknown
 ARG GIT_HASH=unknown
@@ -34,19 +34,12 @@ ARG GIT_HASH=unknown
 ENV GIT_BRANCH=$GIT_BRANCH
 ENV GIT_HASH=$GIT_HASH
 
-USER root
-
-# hadolint ignore=DL3018
-RUN apk --no-cache add curl
-
 WORKDIR /app/qubership-api-linter-service
 
-COPY --from=builder /workspace/qubership-api-linter-service/qubership-api-linter-service ./qubership-api-linter-service
-COPY --from=builder /workspace/qubership-api-linter-service/resources ./resources
-COPY docs/api ./api
+COPY --chown=10001:0 --chmod=555 --from=builder /workspace/qubership-api-linter-service/qubership-api-linter-service ./qubership-api-linter-service
+COPY --chown=10001:0 --chmod=555 --from=builder /workspace/qubership-api-linter-service/resources ./resources
+COPY --chown=10001:0 --chmod=555 docs/api ./api
 
-RUN chmod -R a+rwx /app
+USER 10001:10001
 
-USER 10001
-
-ENTRYPOINT ["./qubership-api-linter-service"]
+CMD ["./qubership-api-linter-service"]

--- a/build_golang_binary.cmd
+++ b/build_golang_binary.cmd
@@ -1,8 +1,11 @@
-set GOSUMDB=off
 set CGO_ENABLED=0
 set GOOS=linux
+set GOARCH=amd64
 cd ./qubership-api-linter-service
 go mod tidy
+if errorlevel 1 exit /b 1
 go mod download
+if errorlevel 1 exit /b 1
 go build .
+if errorlevel 1 exit /b 1
 cd ..

--- a/qubership-api-linter-service/client/apihub.go
+++ b/qubership-api-linter-service/client/apihub.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/Netcracker/qubership-api-linter-service/exception"
 	"github.com/Netcracker/qubership-api-linter-service/secctx"
+	"github.com/Netcracker/qubership-api-linter-service/utils"
 	"github.com/Netcracker/qubership-api-linter-service/view"
 
 	"time"
@@ -46,7 +46,7 @@ type ApihubClient interface {
 	GetSystemInfo(ctx context.Context) (*view.ApihubSystemInfo, error)
 }
 
-func NewApihubClient(apihubUrl, accessToken string) ApihubClient {
+func NewApihubClient(apihubUrl, accessToken string) (ApihubClient, error) {
 	parsedApihubUrl, err := url.Parse(apihubUrl)
 	apihubHost := ""
 	if err != nil {
@@ -55,14 +55,16 @@ func NewApihubClient(apihubUrl, accessToken string) ApihubClient {
 		apihubHost = parsedApihubUrl.Hostname()
 	}
 
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
-	client := resty.NewWithClient(&cl)
+	cl, err := newSecureHTTPClient(time.Second * 60)
+	if err != nil {
+		return nil, fmt.Errorf("create APIHUB HTTP client: %w", err)
+	}
+	client := resty.NewWithClient(cl)
 	if apihubHost != "" {
 		client.SetRedirectPolicy(resty.DomainCheckRedirectPolicy(apihubHost))
 	}
 
-	return &apihubClientImpl{apihubUrl: apihubUrl, accessToken: accessToken, apiHubHost: apihubHost, client: client}
+	return &apihubClientImpl{apihubUrl: apihubUrl, accessToken: accessToken, apiHubHost: apihubHost, client: client}, nil
 }
 
 type apihubClientImpl struct {
@@ -73,10 +75,12 @@ type apihubClientImpl struct {
 }
 
 func (a apihubClientImpl) GetApiKeyByKey(apiKey string) (*view.ApihubApiKeyView, error) {
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
+	cl, err := newSecureHTTPClient(time.Second * 60)
+	if err != nil {
+		return nil, err
+	}
 
-	client := resty.NewWithClient(&cl)
+	client := resty.NewWithClient(cl)
 	req := client.R()
 
 	req.SetHeader("api-key", apiKey)
@@ -496,10 +500,12 @@ func (a apihubClientImpl) GetOperationWithData(ctx context.Context, packageId, v
 }
 
 func (a apihubClientImpl) CheckAuthToken(ctx context.Context, token string) (bool, error) {
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
+	cl, err := newSecureHTTPClient(time.Second * 60)
+	if err != nil {
+		return false, err
+	}
 
-	client := resty.NewWithClient(&cl)
+	client := resty.NewWithClient(cl)
 	req := client.R()
 	req.SetContext(ctx)
 	req.SetHeader("Cookie", fmt.Sprintf("%s=%s", view.AccessTokenCookieName, token))
@@ -515,10 +521,12 @@ func (a apihubClientImpl) CheckAuthToken(ctx context.Context, token string) (boo
 }
 
 func (a apihubClientImpl) GetUserByPAT(ctx context.Context, token string) (*view.User, error) {
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
+	cl, err := newSecureHTTPClient(time.Second * 60)
+	if err != nil {
+		return nil, err
+	}
 
-	client := resty.NewWithClient(&cl)
+	client := resty.NewWithClient(cl)
 	req := client.R()
 	req.SetContext(ctx)
 	req.SetHeader("X-Personal-Access-Token", token)
@@ -541,10 +549,12 @@ func (a apihubClientImpl) GetUserByPAT(ctx context.Context, token string) (*view
 }
 
 func (a apihubClientImpl) GetPatByPAT(ctx context.Context, token string) (*view.PersonalAccessTokenExtAuthView, error) {
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
+	cl, err := newSecureHTTPClient(time.Second * 60)
+	if err != nil {
+		return nil, err
+	}
 
-	client := resty.NewWithClient(&cl)
+	client := resty.NewWithClient(cl)
 	req := client.R()
 	req.SetContext(ctx)
 	req.SetHeader("X-Personal-Access-Token", token)
@@ -601,6 +611,15 @@ func (a apihubClientImpl) GetSystemInfo(ctx context.Context) (*view.ApihubSystem
 		return nil, err
 	}
 	return &config, nil
+}
+
+func newSecureHTTPClient(timeout time.Duration) (*http.Client, error) {
+	tlsConfig, err := utils.BuildSecureTLSConfig(nil)
+	if err != nil {
+		return nil, err
+	}
+	tr := http.Transport{TLSClientConfig: tlsConfig}
+	return &http.Client{Transport: &tr, Timeout: timeout}, nil
 }
 
 func (a apihubClientImpl) makeRequest(ctx context.Context) *resty.Request {

--- a/qubership-api-linter-service/client/openai.go
+++ b/qubership-api-linter-service/client/openai.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Netcracker/qubership-api-linter-service/utils"
 	"github.com/Netcracker/qubership-api-linter-service/view"
 	"github.com/invopop/jsonschema"
 	"github.com/openai/openai-go/v3"
@@ -64,9 +64,13 @@ func NewOpenaiClient(apiKey string, model string, proxy string, rateLimitRPS flo
 		openAIModel = openai.ChatModelGPT5
 	}
 
+	tlsConfig, err := utils.BuildSecureTLSConfig(nil)
+	if err != nil {
+		return nil, fmt.Errorf("build TLS config: %w", err)
+	}
 	tr := http.Transport{
 		Dial:                  dialTimeout,
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig:       tlsConfig,
 		TLSHandshakeTimeout:   time.Second * 1800,
 		IdleConnTimeout:       time.Second * 1800,
 		ResponseHeaderTimeout: time.Second * 1800,

--- a/qubership-api-linter-service/service.go
+++ b/qubership-api-linter-service/service.go
@@ -42,6 +42,9 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	if err := utils.ValidateTLSAtStartup(); err != nil {
+		log.Fatalf("TLS configuration failed: %v", err)
+	}
 
 	basePath := systemInfoService.GetBasePath()
 	r := mux.NewRouter().SkipClean(true).UseEncodedPath()
@@ -114,7 +117,10 @@ func main() {
 		panic("Failed to create olricProvider: " + err.Error())
 	}
 
-	apihubClient := client.NewApihubClient(systemInfoService.GetAPIHubUrl(), systemInfoService.GetApihubAccessToken())
+	apihubClient, err := client.NewApihubClient(systemInfoService.GetAPIHubUrl(), systemInfoService.GetApihubAccessToken())
+	if err != nil {
+		log.Fatalf("Failed to create APIHUB client: %v", err)
+	}
 
 	utils.SafeAsync(func() {
 		systemInfoService.SetProductionMode(apihubClient)

--- a/qubership-api-linter-service/utils/TLSUtils.go
+++ b/qubership-api-linter-service/utils/TLSUtils.go
@@ -1,0 +1,77 @@
+// Copyright 2024-2025 NetCracker Technology Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"sync"
+)
+
+var (
+	baseTLSOnce sync.Once
+	baseTLSCfg  *tls.Config
+	baseTLSErr  error
+)
+
+// ValidateTLSAtStartup validates the default TLS configuration at process startup.
+func ValidateTLSAtStartup() error {
+	_, err := BuildSecureTLSConfig(nil)
+	return err
+}
+
+// BuildSecureTLSConfig returns a TLS configuration with proper certificate validation.
+// It uses the system certificate pool and optional inline PEM data.
+//
+// In container deployments based on ghcr.io/netcracker/qubership-core-base, custom CA certificates
+// are loaded into the system trust store by the base image entrypoint from /tmp/cert/ before the
+// application starts. Mount .crt, .cer, or .pem files there in Compose or Kubernetes.
+func BuildSecureTLSConfig(customPEM []byte) (*tls.Config, error) {
+	if len(customPEM) == 0 {
+		baseTLSOnce.Do(func() {
+			baseTLSCfg, baseTLSErr = buildSecureTLSConfig(nil)
+		})
+		if baseTLSErr != nil {
+			return nil, baseTLSErr
+		}
+		return baseTLSCfg.Clone(), nil
+	}
+	return buildSecureTLSConfig(customPEM)
+}
+
+func buildSecureTLSConfig(customPEM []byte) (*tls.Config, error) {
+	rootCAs, err := buildRootCertPool(customPEM)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		RootCAs:    rootCAs,
+		MinVersion: tls.VersionTLS12,
+	}, nil
+}
+
+func buildRootCertPool(customPEM []byte) (*x509.CertPool, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("load system certificate pool: %w", err)
+	}
+	if len(customPEM) > 0 {
+		if ok := pool.AppendCertsFromPEM(customPEM); !ok {
+			return nil, fmt.Errorf("parse custom PEM certificate")
+		}
+	}
+	return pool, nil
+}


### PR DESCRIPTION
## Summary

- Replaces `InsecureSkipVerify: true` with proper certificate validation via centralized `utils/TLSUtils.go`.
- **Fail-fast:** TLS certificate loading errors propagate and abort startup (`ValidateTLSAtStartup` in `service.go`).
- **APIHUB client** and **OpenAI client** outbound HTTP use the same secure TLS configuration.
- **Runtime image:** uses [`ghcr.io/netcracker/qubership-core-base:2.3.3`](https://github.com/Netcracker/qubership-core-base-images) instead of plain Alpine — reuses the platform certificate contract.

## Certificate contract (core-base)

Custom CA certificates are loaded by the base image entrypoint from **`/tmp/cert/`** before the app starts (Compose volume or K8s Secret/ConfigMap mount). Go HTTP clients use `x509.SystemCertPool()` and pick up those CAs automatically.

Pairs with:
- Backend secure TLS: [qubership-apihub-backend#456](https://github.com/Netcracker/qubership-apihub-backend/pull/456)
- Deployment Helm/Compose: [qubership-apihub#683](https://github.com/Netcracker/qubership-apihub/pull/683)

## Test plan

- [ ] Linter starts in core-base image without custom certs (public HTTPS works).
- [ ] APIHUB API calls over HTTPS work with CA mounted to `/tmp/cert/`.
- [ ] OpenAI outbound calls (when AI linter enabled) over HTTPS with corporate CA.
- [ ] Health probes (`/ready`, `/live`) still pass.
- [ ] E2E CI pipeline green on this PR.